### PR TITLE
ioxide 0.0.9: restore plain-send inlining (UseZc branch, not a SendFn function pointer)

### DIFF
--- a/ioxide.file/ioxide.file.csproj
+++ b/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.0.8</Version>
+    <Version>0.0.9</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.pg/ioxide.pg.csproj
+++ b/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.0.8</Version>
+    <Version>0.0.9</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.redis/ioxide.redis.csproj
+++ b/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.0.8</Version>
+    <Version>0.0.9</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.tls/ioxide.tls.csproj
+++ b/ioxide.tls/ioxide.tls.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.tls</RootNamespace>
 
     <PackageId>ioxide.tls</PackageId>
-    <Version>0.0.8</Version>
+    <Version>0.0.9</Version>
     <Authors>MDA2AV</Authors>
     <Description>TLS for the ioxide io_uring runtime: OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload - handlers keep writing plaintext through the same connection API. Requires Linux kTLS (tls module) and OpenSSL 3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide/Connection/Connection.cs
+++ b/ioxide/Connection/Connection.cs
@@ -13,11 +13,12 @@ public sealed unsafe partial class Connection
     public ushort ListenerPort { get; internal set; }
 
     /// <summary>
-    /// The reactor's injected send strategy for this connection (plain SEND or SEND_ZC), bound at
-    /// accept from <see cref="ServerConfig.ZeroCopySend"/>. kTLS forces it back to plain via the
-    /// <see cref="SendOpFlags"/> setter.
+    /// Whether this connection sends with SEND_ZC (zero-copy). Bound at accept from
+    /// <see cref="ServerConfig.ZeroCopySend"/>; kTLS forces it back to plain via the
+    /// <see cref="SendOpFlags"/> setter. The reactor branches on this bool per send instead of
+    /// dispatching through an indirect function pointer.
     /// </summary>
-    internal delegate*<Reactor, int, ushort, byte*, uint, uint, void> SendFn;
+    internal bool UseZc;
 
     private uint _sendOpFlags = 0x100;   // MSG_WAITALL
 
@@ -36,7 +37,7 @@ public sealed unsafe partial class Connection
             _sendOpFlags = value;
             if (value == 0)
             {
-                SendFn = &Reactor.SubmitSendPlain;
+                UseZc = false;
             }
         }
     }

--- a/ioxide/Reactor/Reactor.cs
+++ b/ioxide/Reactor/Reactor.cs
@@ -24,9 +24,10 @@ public sealed unsafe partial class Reactor
     private ushort[] _listenPorts = [];
     private readonly ServerConfig _config;
 
-    // The response-send strategy, chosen once from config (ZeroCopySend) and injected per-connection
-    // at accept via Connection.SendFn. Keeps the send hot path free of a per-call branch.
-    private readonly delegate*<Reactor, int, ushort, byte*, uint, uint, void> _sendFn;
+    // The response-send strategy from config (ZeroCopySend), copied per-connection at accept into
+    // Connection.UseZc. The send hot path branches on that bool (predictable, inlinable) instead of
+    // dispatching through an indirect function pointer.
+    private readonly bool _zeroCopySend;
     private readonly ushort _port;
     private readonly uint _ringEntries;
     private readonly bool _incremental;
@@ -103,7 +104,7 @@ public sealed unsafe partial class Reactor
         ConnBufRingEntries = config.ConnBufRingEntries;
         IncRecvBufferSize = (uint)config.IncRecvBufferSize;
         _pool = new Stack<Connection>(config.PoolMax);
-        _sendFn = config.ZeroCopySend ? &SubmitSendZc : &SubmitSendPlain;
+        _zeroCopySend = config.ZeroCopySend;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -214,7 +215,7 @@ public sealed unsafe partial class Reactor
             Connection? conn = ConnAt(fd, (ushort)gen);
             if (conn != null)
             {
-                conn.SendFn(this, fd, (ushort)gen, conn.WriteBuffer, (uint)conn.WriteInFlight, conn.SendOpFlags);
+                SubmitSend(conn, fd, (ushort)gen, conn.WriteBuffer, (uint)conn.WriteInFlight, conn.SendOpFlags);
             }
             return;
         }
@@ -272,7 +273,7 @@ public sealed unsafe partial class Reactor
             {
                 continue;
             }
-            conn.SendFn(this, fd, gen, conn.WriteBuffer, (uint)conn.WriteInFlight, conn.SendOpFlags);
+            SubmitSend(conn, fd, gen, conn.WriteBuffer, (uint)conn.WriteInFlight, conn.SendOpFlags);
         }
     }
 
@@ -471,7 +472,7 @@ public sealed unsafe partial class Reactor
                         : new Connection(this, clientFd, _config.WriteSlabSize, _config.RecvQueueEntries);
                     Track(clientFd, conn);
                     conn.InitRefs();
-                    conn.SendFn = _sendFn;   // config default; kTLS overrides to plain on handshake
+                    conn.UseZc = _zeroCopySend;   // config default; kTLS overrides to plain on handshake
                     conn.ListenerPort = PortOf(fd);
                     SubmitRecvMultishot(clientFd, (ushort)conn.Generation, BgId);
 
@@ -541,8 +542,8 @@ public sealed unsafe partial class Reactor
 
         if (conn.WriteHead < conn.WriteInFlight)
         {
-            // Partial send (rare with MSG_WAITALL): resubmit the remainder via the injected sender.
-            conn.SendFn(this, fd, gen, conn.WriteBuffer + conn.WriteHead, (uint)(conn.WriteInFlight - conn.WriteHead), conn.SendOpFlags);
+            // Partial send (rare with MSG_WAITALL): resubmit the remainder.
+            SubmitSend(conn, fd, gen, conn.WriteBuffer + conn.WriteHead, (uint)(conn.WriteInFlight - conn.WriteHead), conn.SendOpFlags);
             return;
         }
 
@@ -659,13 +660,20 @@ public sealed unsafe partial class Reactor
         sqe->user_data = Tag(KindRecv, gen, fd);
     }
 
-    // The two injectable send strategies (see _sendFn / Connection.SendFn). Static so they can be
-    // taken as function pointers; the chosen one is bound per-connection at accept.
-    internal static void SubmitSendPlain(Reactor r, int fd, ushort gen, byte* buf, uint len, uint opFlags)
-        => SubmitSendImpl(r, IORING_OP_SEND, fd, gen, buf, len, opFlags);
-
-    internal static void SubmitSendZc(Reactor r, int fd, ushort gen, byte* buf, uint len, uint opFlags)
-        => SubmitSendImpl(r, IORING_OP_SEND_ZC, fd, gen, buf, len, opFlags);
+    // Dispatch a send to this connection's strategy. A predictable per-connection branch (ZeroCopySend
+    // is constant for the run; kTLS pins plain) instead of an indirect call - so SubmitSendImpl stays
+    // inlinable on the hot send path.
+    private void SubmitSend(Connection conn, int fd, ushort gen, byte* buf, uint len, uint opFlags)
+    {
+        if (conn.UseZc)
+        {
+            SubmitSendImpl(this, IORING_OP_SEND_ZC, fd, gen, buf, len, opFlags);
+        }
+        else
+        {
+            SubmitSendImpl(this, IORING_OP_SEND, fd, gen, buf, len, opFlags);
+        }
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void SubmitSendImpl(Reactor r, byte opcode, int fd, ushort gen, byte* buf, uint len, uint opFlags)

--- a/ioxide/ioxide.csproj
+++ b/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.0.8</Version>
+    <Version>0.0.9</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## What

ioxide 0.0.9. Restores the plain-send throughput that the 0.0.8 opt-in zero-copy send regressed.

## Why

0.0.8 (#78) routed every send through a per-connection function pointer (`Connection.SendFn`, a `delegate*`), chosen at accept from `ServerConfig.ZeroCopySend`. With ZC off (the default), the plain-SEND hot path still paid an indirect call and lost inlining of `SubmitSendImpl` — a measurable throughput loss on every response, across all profiles.

## Fix

Replace the function pointer with a per-connection `bool UseZc` and a predictable branch in the send loop (`if (conn.UseZc) ... else ...`). `ZeroCopySend` is constant for the run and kTLS pins plain, so the branch predicts perfectly and `SubmitSendImpl` inlines again. Zero-copy behavior is unchanged — same opcodes, and the `ZcNotifPending` / `F_NOTIF` / `F_MORE` completion logic is untouched.