### PR TITLE
Reactor: graceful shutdown to free the io_uring ring (bump to 0.0.10)

### DIFF
--- a/ioxide.file/ioxide.file.csproj
+++ b/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.0.9</Version>
+    <Version>0.0.10</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.pg/ioxide.pg.csproj
+++ b/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.0.9</Version>
+    <Version>0.0.10</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.redis/ioxide.redis.csproj
+++ b/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.0.9</Version>
+    <Version>0.0.10</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.tls/ioxide.tls.csproj
+++ b/ioxide.tls/ioxide.tls.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.tls</RootNamespace>
 
     <PackageId>ioxide.tls</PackageId>
-    <Version>0.0.9</Version>
+    <Version>0.0.10</Version>
     <Authors>MDA2AV</Authors>
     <Description>TLS for the ioxide io_uring runtime: OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload - handlers keep writing plaintext through the same connection API. Requires Linux kTLS (tls module) and OpenSSL 3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide/Reactor/Reactor.Incremental.cs
+++ b/ioxide/Reactor/Reactor.Incremental.cs
@@ -155,7 +155,7 @@ public sealed unsafe partial class Reactor
 
     private void LoopIncremental()
     {
-        while (true)
+        while (!_stopRequested)
         {
             DrainReturnQIncremental();
             DrainFlushQ();

--- a/ioxide/Reactor/Reactor.cs
+++ b/ioxide/Reactor/Reactor.cs
@@ -62,6 +62,10 @@ public sealed unsafe partial class Reactor
     private int _wakeFd;
     private int _reactorThreadId;
 
+    // Set cross-thread by Stop(); the loops check it at the top of each iteration and exit, after which
+    // Run() tears the ring down on this (the reactor) thread - mandatory for a single-issuer ring.
+    private volatile bool _stopRequested;
+
     // Periodic timer driving registered tickers (per-command timeout sweeps, pool replenishment).
     // Single-shot, re-armed each fire. One timer in flight per reactor.
     private __kernel_timespec* _timerTs;
@@ -296,6 +300,25 @@ public sealed unsafe partial class Reactor
         sqe->user_data = Tag(KindWake, 0, _wakeFd);
     }
 
+    /// <summary>
+    /// Requests the reactor to stop. Safe to call from any thread. The loop finishes its current
+    /// iteration and exits, then <see cref="Run"/> closes the listeners and wake fd and disposes the
+    /// io_uring ring on the reactor thread (a single-issuer / DEFER_TASKRUN ring must be torn down on the
+    /// thread that owns it). Join the reactor thread after calling this to await teardown.
+    /// </summary>
+    public void Stop()
+    {
+        _stopRequested = true;
+
+        // Wake a loop parked in io_uring_enter so it observes the flag promptly. Writing the eventfd is
+        // the only ring-adjacent action safe off the reactor thread. The guard covers Stop() racing ahead
+        // of Run() creating _wakeFd - the loop still sees the flag on its first iteration.
+        if (_wakeFd > 0)
+        {
+            WakeFdWrite();
+        }
+    }
+
     public void Run()
     {
         _reactorThreadId = Environment.CurrentManagedThreadId;
@@ -359,6 +382,18 @@ public sealed unsafe partial class Reactor
         {
             close(listenFd);
         }
+
+        // Close any still-open accepted sockets (the connection table is indexed by fd) so they don't
+        // leak when a host is disposed and recreated many times in one process - e.g. across a test run.
+        for (int fd = 0; fd < _connections.Length; fd++)
+        {
+            if (_connections[fd] != null)
+            {
+                close(fd);
+                _connections[fd] = null;
+            }
+        }
+
         close(_wakeFd);
         if (_timerTs != null)
         {
@@ -366,11 +401,24 @@ public sealed unsafe partial class Reactor
             _timerTs = null;
         }
         Ring.Dispose();
+
+        // Shared provided-buffer ring (incremental mode allocates per connection instead). Freed after
+        // the ring fd is closed, so the kernel has dropped its references to the slab.
+        if (_bufRing != null)
+        {
+            NativeMemory.AlignedFree(_bufRing);
+            _bufRing = null;
+        }
+        if (_bufSlab != null)
+        {
+            NativeMemory.AlignedFree(_bufSlab);
+            _bufSlab = null;
+        }
     }
 
     private void LoopShared()
     {
-        while (true)
+        while (!_stopRequested)
         {
             DrainReturnQ();
             DrainFlushQ();

--- a/ioxide/ioxide.csproj
+++ b/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.0.9</Version>
+    <Version>0.0.10</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Problem

`Reactor` had no way to stop. Once `reactor.Run()` was started on a thread, the loop (`LoopShared` / `LoopIncremental`) ran `while (true)` forever, so the io_uring ring it created was never released. A long-lived process that creates and disposes many hosts — e.g. a test suite that spins up a host per test, each with one reactor per core — accumulates io_uring instances until `io_uring_setup` fails:

```
Unhandled exception. System.InvalidOperationException: io_uring_setup failed: -1
```

and the process aborts (SIGABRT / exit 134). It only reproduces "at scale" — a single host, or one module's tests, stays well under the kernel's per-process ceiling.

## Fix

- Add a public, thread-safe **`Reactor.Stop()`**: sets a `volatile bool _stopRequested` and writes the existing wake `eventfd` so a loop parked in `io_uring_enter` returns promptly.
- Both loops now run `while (!_stopRequested)`.
- `Run()`'s existing post-loop teardown frees everything **on the reactor thread** (required for a `SINGLE_ISSUER` / `DEFER_TASKRUN` ring): close listeners, **close still-open accepted sockets**, close the wake fd, free the timer, `Ring.Dispose()`, and **free the shared buffer-ring slab**.

Writing the eventfd is the only ring-adjacent action performed off the reactor thread; all SQ/CQ/ring teardown stays on the owning thread. Callers stop a reactor with `Stop()`, then `Join()` its thread to await full teardown.

## Result

Verified with a host created/disposed per test across a large suite (744 tests): the live io_uring ring count now rises and falls with each host — peaking at roughly two hosts' worth during teardown/startup overlap and returning to **0** between tests — instead of climbing monotonically to ~**9,760** and crashing at ~test 417. After the fix the full suite runs to completion with **0** `io_uring_setup` failures and **0** host crashes.

## Versions

All packages bumped to **0.0.10**: `ioxide`, `ioxide.tls`, `ioxide.file`, `ioxide.pg`, `ioxide.redis`. The sub-packages reference `ioxide` via `ProjectReference`, so they pick up the `0.0.10` dependency automatically.
