### PR TITLE
Add ioxide.Kestrel: ASP.NET Core Kestrel transport on the io_uring reactor

### DIFF
--- a/Examples.AspNet/Examples.AspNet.csproj
+++ b/Examples.AspNet/Examples.AspNet.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net11.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>Examples.AspNet</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../ioxide.Kestrel/ioxide.Kestrel.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Examples.AspNet/Program.cs
+++ b/Examples.AspNet/Program.cs
@@ -1,4 +1,5 @@
 using ioxide.Kestrel;
+using Microsoft.Extensions.Logging;
 
 // A minimal ASP.NET Core app that runs on either the ioxide io_uring transport or Kestrel's stock
 // sockets transport. Pick with the TRANSPORT environment variable (default: ioxide):
@@ -9,6 +10,8 @@ using ioxide.Kestrel;
 // Then: curl http://localhost:8080/  and  curl http://localhost:8080/plaintext
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Logging.ClearProviders();   // turn off all logging (no per-request info: lines)
 
 var transport = (Environment.GetEnvironmentVariable("TRANSPORT") ?? "ioxide").Trim().ToLowerInvariant();
 

--- a/Examples.AspNet/Program.cs
+++ b/Examples.AspNet/Program.cs
@@ -1,0 +1,39 @@
+using ioxide.Kestrel;
+
+// A minimal ASP.NET Core app that runs on either the ioxide io_uring transport or Kestrel's stock
+// sockets transport. Pick with the TRANSPORT environment variable (default: ioxide):
+//
+//   TRANSPORT=ioxide  dotnet run     # ioxide.Kestrel transport (io_uring, one reactor per core)
+//   TRANSPORT=sockets dotnet run     # stock Kestrel sockets transport (the framework default)
+//
+// Then: curl http://localhost:8080/  and  curl http://localhost:8080/plaintext
+
+var builder = WebApplication.CreateBuilder(args);
+
+var transport = (Environment.GetEnvironmentVariable("TRANSPORT") ?? "ioxide").Trim().ToLowerInvariant();
+
+builder.WebHost.ConfigureKestrel(o => o.ListenAnyIP(8080));
+
+switch (transport)
+{
+    case "ioxide":
+        builder.WebHost.UseIoxide();   // io_uring transport from the ioxide.Kestrel package
+        break;
+
+    case "sockets":
+    case "kestrel":
+        // Stock Kestrel sockets transport — the framework default, nothing to wire up.
+        break;
+
+    default:
+        Console.Error.WriteLine($"Unknown TRANSPORT '{transport}'. Use 'ioxide' or 'sockets'.");
+        return;
+}
+
+var app = builder.Build();
+
+app.MapGet("/", () => $"Hello from ioxide.Kestrel! transport={transport}");
+app.MapGet("/plaintext", () => "Hello, World!");
+
+Console.WriteLine($"[Examples.AspNet] listening on http://localhost:8080  (transport={transport})");
+app.Run();

--- a/Examples.AspNet/Program.cs
+++ b/Examples.AspNet/Program.cs
@@ -17,7 +17,7 @@ builder.WebHost.ConfigureKestrel(o => o.ListenAnyIP(8080));
 switch (transport)
 {
     case "ioxide":
-        builder.WebHost.UseIoxide();   // io_uring transport from the ioxide.Kestrel package
+        builder.WebHost.UseIoxide(o => o.ReactorCount = 16);   // io_uring transport, 16 reactors (one ring per thread)
         break;
 
     case "sockets":

--- a/ioxide.Kestrel/HopDuplexPipe.cs
+++ b/ioxide.Kestrel/HopDuplexPipe.cs
@@ -1,0 +1,152 @@
+using System.Buffers;
+using System.IO.Pipelines;
+using ioxide;
+using ioxide.utils;
+
+namespace ioxide.Kestrel;
+
+/// <summary>
+/// A Kestrel transport duplex over an ioxide <see cref="Connection"/>: two BCL <see cref="Pipe"/>s whose
+/// reader schedulers route to the reactor thread (via <see cref="ReactorPipeScheduler"/>), plus a
+/// recv→inbound pump and an outbound→send pump that run on the reactor. This pins Kestrel's whole request
+/// loop to the reactor thread. One copy each way (recv bytes into the inbound pipe; response bytes into
+/// the connection slab).
+/// </summary>
+internal sealed class HopDuplexPipe : IDuplexPipe, IAsyncDisposable
+{
+    private readonly Connection _conn;
+    private readonly Reactor _reactor;
+    private readonly Pipe _inbound;    // recv pump writes; Kestrel reads (Transport.Input)
+    private readonly Pipe _outbound;   // Kestrel writes (Transport.Output); send pump reads
+
+    private Task _recvPump = Task.CompletedTask;
+    private Task _sendPump = Task.CompletedTask;
+    private int _started;
+
+    public PipeReader Input => _inbound.Reader;
+    public PipeWriter Output => _outbound.Writer;
+
+    public HopDuplexPipe(Connection conn, Reactor reactor)
+    {
+        _conn = conn;
+        _reactor = reactor;
+        var scheduler = new ReactorPipeScheduler(reactor);
+
+        // Reader schedulers = the reactor: Kestrel's HTTP parse (inbound reader) and the send pump
+        // (outbound reader) both run on the reactor thread.
+        _inbound = new Pipe(new PipeOptions(
+            readerScheduler: scheduler,
+            writerScheduler: scheduler,
+            pauseWriterThreshold: 1024 * 1024,
+            resumeWriterThreshold: 512 * 1024,
+            useSynchronizationContext: false));
+
+        _outbound = new Pipe(new PipeOptions(
+            readerScheduler: scheduler,
+            writerScheduler: PipeScheduler.ThreadPool,
+            pauseWriterThreshold: 64 * 1024,
+            resumeWriterThreshold: 32 * 1024,
+            useSynchronizationContext: false));
+    }
+
+    /// <summary>Launches the recv and send pumps. Must be called on the reactor thread.</summary>
+    public void Start()
+    {
+        if (Interlocked.Exchange(ref _started, 1) == 1)
+        {
+            return;
+        }
+        _recvPump = RecvPumpAsync();
+        _sendPump = SendPumpAsync();
+    }
+
+    // Reactor → inbound pipe. Copies each recv slice into the pipe and flushes; Kestrel reads it.
+    private async Task RecvPumpAsync()
+    {
+        PipeWriter writer = _inbound.Writer;
+        try
+        {
+            while (true)
+            {
+                RecvSnapshot snap = await _conn.ReadAsync();
+
+                while (_conn.TryGetItem(snap, out SpscRecvRing.Item item))
+                {
+                    if (item.HasBuffer && item.Len > 0)
+                    {
+                        CopySlice(in item, writer);
+                    }
+                    _conn.ReturnBuffer(in item);
+                }
+                _conn.ResetRead();
+
+                if (snap.IsClosed)
+                {
+                    break;
+                }
+
+                FlushResult fr = await writer.FlushAsync();
+                if (fr.IsCompleted || fr.IsCanceled)
+                {
+                    break;
+                }
+            }
+        }
+        catch { /* swallow client/protocol faults; teardown in finally */ }
+        finally { await writer.CompleteAsync(); }
+    }
+
+    private static unsafe void CopySlice(in SpscRecvRing.Item item, PipeWriter writer)
+    {
+        Span<byte> dst = writer.GetSpan(item.Len);
+        new ReadOnlySpan<byte>(item.Ptr, item.Len).CopyTo(dst);
+        writer.Advance(item.Len);
+    }
+
+    // Outbound pipe → connection send. Drains Kestrel's response into the slab and submits one SEND.
+    private async Task SendPumpAsync()
+    {
+        PipeReader reader = _outbound.Reader;
+        try
+        {
+            while (true)
+            {
+                ReadResult rr = await reader.ReadAsync();
+                ReadOnlySequence<byte> buffer = rr.Buffer;
+
+                if (!buffer.IsEmpty)
+                {
+                    foreach (ReadOnlyMemory<byte> segment in buffer)
+                    {
+                        Span<byte> dst = _conn.GetSpan(segment.Length);
+                        segment.Span.CopyTo(dst);
+                        _conn.Advance(segment.Length);
+                    }
+                    await _conn.FlushAsync();
+                }
+
+                reader.AdvanceTo(buffer.End);
+
+                if (rr.IsCompleted || rr.IsCanceled)
+                {
+                    break;
+                }
+            }
+        }
+        catch { /* swallow; teardown in finally */ }
+        finally { await reader.CompleteAsync(); }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // Kestrel has completed its ends; wake the pumps and unwind. MarkClosed wakes a recv parked in
+        // conn.ReadAsync — schedule it ON the reactor so the recv continuation (which touches reactor-owned
+        // recv state) runs there, not on Kestrel's dispose thread. The pipe cancels resume via the pipes'
+        // reactor reader/writer schedulers, so they're reactor-safe too.
+        _reactor.ScheduleOnReactor(static c => ((Connection)c!).MarkClosed(), _conn);
+        _inbound.Writer.CancelPendingFlush();
+        _outbound.Reader.CancelPendingRead();
+        try { await _recvPump; } catch { }
+        try { await _sendPump; } catch { }
+    }
+}

--- a/ioxide.Kestrel/IoxideConnectionContext.cs
+++ b/ioxide.Kestrel/IoxideConnectionContext.cs
@@ -1,0 +1,93 @@
+using System.IO.Pipelines;
+using System.Net;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.AspNetCore.Http.Features;
+using ioxide;
+
+namespace ioxide.Kestrel;
+
+/// <summary>
+/// Adapts a single ioxide <see cref="Connection"/> to Kestrel's <see cref="ConnectionContext"/>. The
+/// transport is a <see cref="HopDuplexPipe"/> (BCL pipes whose reader schedulers route to the reactor),
+/// so Kestrel's read → parse → handle → send loop runs pinned to the reactor thread.
+/// </summary>
+internal sealed class IoxideConnectionContext : ConnectionContext,
+    IConnectionIdFeature,
+    IConnectionTransportFeature,
+    IConnectionItemsFeature,
+    IConnectionLifetimeFeature,
+    IConnectionEndPointFeature
+{
+    private readonly HopDuplexPipe _pipe;
+    private readonly CancellationTokenSource _connectionClosedCts = new();
+    private readonly FeatureCollection _features = new();
+
+    // Completed when Kestrel is done with the connection (DisposeAsync, or Abort). The ioxide Handle
+    // callback awaits this and only then DecRefs the connection.
+    private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private int _disposed;
+
+    public IoxideConnectionContext(Connection connection, Reactor reactor, EndPoint localEndPoint, long id)
+    {
+        _pipe = new HopDuplexPipe(connection, reactor);
+
+        ConnectionId = $"ioxide-{id:x}";
+        LocalEndPoint = localEndPoint;
+        RemoteEndPoint = null;
+        Items = new ConnectionItems();
+        ConnectionClosed = _connectionClosedCts.Token;
+
+        _features.Set<IConnectionIdFeature>(this);
+        _features.Set<IConnectionTransportFeature>(this);
+        _features.Set<IConnectionItemsFeature>(this);
+        _features.Set<IConnectionLifetimeFeature>(this);
+        _features.Set<IConnectionEndPointFeature>(this);
+    }
+
+    /// <summary>Resolves once Kestrel has finished with this connection; the reactor's Handle callback awaits it.</summary>
+    public Task Completion => _completion.Task;
+
+    /// <summary>Launches the transport pumps. Must be called on the reactor thread (from the Handle callback).</summary>
+    public void StartPumps() => _pipe.Start();
+
+    public override string ConnectionId { get; set; }
+    public override IFeatureCollection Features => _features;
+    public override IDictionary<object, object?> Items { get; set; }
+
+    public override IDuplexPipe Transport
+    {
+        get => _pipe;
+        set => throw new NotSupportedException("Transport is owned by the ioxide transport adapter.");
+    }
+
+    public override CancellationToken ConnectionClosed { get; set; }
+    public override EndPoint? LocalEndPoint { get; set; }
+    public override EndPoint? RemoteEndPoint { get; set; }
+
+    public override void Abort(ConnectionAbortedException abortReason)
+    {
+        // Forced close: signal the lifetime token. The pumps are unwound (reactor-safely) in DisposeAsync,
+        // which Kestrel calls during connection cleanup after Abort.
+        try { _connectionClosedCts.Cancel(); } catch { /* ignore */ }
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) == 1)
+        {
+            return;
+        }
+
+        try { _connectionClosedCts.Cancel(); } catch { /* ignore */ }
+
+        // Unwind the recv/send pumps (returns held recv buffers, stops the send loop).
+        await _pipe.DisposeAsync().ConfigureAwait(false);
+
+        _connectionClosedCts.Dispose();
+
+        // Release the reactor's Handle callback, which DecRefs the connection (-> recycle).
+        _completion.TrySetResult();
+    }
+}

--- a/ioxide.Kestrel/IoxideConnectionListener.cs
+++ b/ioxide.Kestrel/IoxideConnectionListener.cs
@@ -1,0 +1,139 @@
+using System.Net;
+using System.Threading.Channels;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.Logging;
+using ioxide;
+
+namespace ioxide.Kestrel;
+
+/// <summary>
+/// Runs a fleet of ioxide reactors (one io_uring ring + thread each, SO_REUSEPORT load-balanced) and
+/// bridges ioxide's push model (per-connection <c>Handle</c> callback on the reactor thread) to Kestrel's
+/// pull model (<see cref="AcceptAsync"/>). The Handle callback wraps each connection, pushes it onto a
+/// channel for Kestrel to dequeue, starts the transport pumps, and then parks until Kestrel disposes the
+/// connection — keeping the connection's handler-side ref alive for its whole Kestrel lifetime.
+/// </summary>
+internal sealed class IoxideConnectionListener : IConnectionListener
+{
+    private readonly ILogger<IoxideConnectionListener> _logger;
+    private readonly Channel<ConnectionContext> _accepted;
+    private readonly Reactor[] _reactors;
+    private readonly Thread[] _threads;
+    private long _connectionCounter;
+    private int _stopped;
+
+    public EndPoint EndPoint { get; }
+
+    public IoxideConnectionListener(IPEndPoint endpoint, IoxideTransportOptions options, ILogger<IoxideConnectionListener> logger)
+    {
+        EndPoint = endpoint;
+        _logger = logger;
+
+        _accepted = Channel.CreateUnbounded<ConnectionContext>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            AllowSynchronousContinuations = false,
+        });
+
+        var reactorCount = Math.Max(1, options.ReactorCount);
+
+        var cfg = new ServerConfig { ReactorCount = reactorCount, Port = (ushort)endpoint.Port };
+        if (options.ConfigureServer is not null)
+        {
+            cfg = options.ConfigureServer(cfg);
+        }
+        cfg = cfg with { Port = (ushort)endpoint.Port, ReactorCount = reactorCount };
+
+        _reactors = new Reactor[reactorCount];
+        _threads = new Thread[reactorCount];
+
+        for (var i = 0; i < reactorCount; i++)
+        {
+            var reactor = new Reactor(i, cfg)
+            {
+                Handle = HandleConnectionAsync,
+            };
+            _reactors[i] = reactor;
+            _threads[i] = new Thread(reactor.Run)
+            {
+                Name = $"ioxide-reactor-{i}",
+                IsBackground = true,
+            };
+        }
+
+        foreach (var thread in _threads)
+        {
+            thread.Start();
+        }
+
+        _logger.LogInformation("[ioxide] Bound {Endpoint} with {ReactorCount} reactor(s)", endpoint, reactorCount);
+    }
+
+    // Runs on the reactor thread, fire-and-forget, once per accepted connection.
+    private async Task HandleConnectionAsync(Reactor reactor, Connection conn)
+    {
+        var id = Interlocked.Increment(ref _connectionCounter);
+        var ctx = new IoxideConnectionContext(conn, reactor, EndPoint, id);
+
+        if (!_accepted.Writer.TryWrite(ctx))
+        {
+            // Listener is shutting down: nobody will dequeue this. Release immediately.
+            await ctx.DisposeAsync().ConfigureAwait(false);
+            conn.DecRef();
+            return;
+        }
+
+        // Launch the recv/send pumps on this reactor thread (we're inside the Handle callback).
+        ctx.StartPumps();
+
+        // Park until Kestrel disposes the connection, then release the handler-side ref (-> recycle).
+        await ctx.Completion.ConfigureAwait(false);
+        conn.DecRef();
+    }
+
+    public async ValueTask<ConnectionContext?> AcceptAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await _accepted.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return null;
+        }
+        catch (ChannelClosedException)
+        {
+            return null;
+        }
+    }
+
+    public ValueTask UnbindAsync(CancellationToken cancellationToken = default)
+    {
+        if (Interlocked.Exchange(ref _stopped, 1) == 0)
+        {
+            _accepted.Writer.TryComplete();
+            _logger.LogInformation("[ioxide] Unbound listener on {Endpoint}", EndPoint);
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _accepted.Writer.TryComplete();
+
+        await Task.Run(() =>
+        {
+            foreach (var reactor in _reactors)
+            {
+                reactor.Stop();
+            }
+            foreach (var thread in _threads)
+            {
+                thread.Join(TimeSpan.FromSeconds(5));
+            }
+        }).ConfigureAwait(false);
+
+        _logger.LogInformation("[ioxide] Stopped {ReactorCount} reactor(s) on {Endpoint}", _reactors.Length, EndPoint);
+    }
+}

--- a/ioxide.Kestrel/IoxideKestrelExtensions.cs
+++ b/ioxide.Kestrel/IoxideKestrelExtensions.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace ioxide.Kestrel;
+
+/// <summary>Hosting extensions for the ioxide Kestrel transport.</summary>
+public static class IoxideKestrelExtensions
+{
+    /// <summary>
+    /// Replaces Kestrel's default sockets transport with the ioxide io_uring transport. Call after
+    /// <c>UseKestrel</c> (or rely on the implicit Kestrel registration that <c>WebApplication.CreateBuilder</c>
+    /// performs) — this evicts any previously-registered <see cref="IConnectionListenerFactory"/>.
+    /// </summary>
+    public static IWebHostBuilder UseIoxide(this IWebHostBuilder builder, Action<IoxideTransportOptions>? configure = null)
+    {
+        return builder.ConfigureServices(services =>
+        {
+            services.AddOptions<IoxideTransportOptions>();
+            if (configure is not null)
+            {
+                services.Configure(configure);
+            }
+
+            services.RemoveAll<IConnectionListenerFactory>();
+            services.AddSingleton<IConnectionListenerFactory, IoxideTransportFactory>();
+        });
+    }
+}

--- a/ioxide.Kestrel/IoxideTransportFactory.cs
+++ b/ioxide.Kestrel/IoxideTransportFactory.cs
@@ -1,0 +1,34 @@
+using System.Net;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace ioxide.Kestrel;
+
+/// <summary>
+/// Kestrel transport that runs each connection on an ioxide reactor fleet. Kestrel calls
+/// <see cref="BindAsync"/> once per configured endpoint; each call spins up its own set of reactors.
+/// </summary>
+internal sealed class IoxideTransportFactory : IConnectionListenerFactory
+{
+    private readonly IoxideTransportOptions _options;
+    private readonly ILoggerFactory _loggerFactory;
+
+    public IoxideTransportFactory(IOptions<IoxideTransportOptions> options, ILoggerFactory loggerFactory)
+    {
+        _options = options.Value;
+        _loggerFactory = loggerFactory;
+    }
+
+    public ValueTask<IConnectionListener> BindAsync(EndPoint endpoint, CancellationToken cancellationToken = default)
+    {
+        if (endpoint is not IPEndPoint ipEndpoint)
+        {
+            throw new NotSupportedException($"ioxide transport only supports {nameof(IPEndPoint)} (got {endpoint.GetType().Name}).");
+        }
+
+        var logger = _loggerFactory.CreateLogger<IoxideConnectionListener>();
+        IConnectionListener listener = new IoxideConnectionListener(ipEndpoint, _options, logger);
+        return ValueTask.FromResult(listener);
+    }
+}

--- a/ioxide.Kestrel/IoxideTransportOptions.cs
+++ b/ioxide.Kestrel/IoxideTransportOptions.cs
@@ -1,0 +1,20 @@
+using ioxide;
+
+namespace ioxide.Kestrel;
+
+/// <summary>Options for the ioxide Kestrel transport.</summary>
+public sealed class IoxideTransportOptions
+{
+    /// <summary>
+    /// Number of ioxide reactors (one io_uring ring + one dedicated thread each), load-balanced by
+    /// SO_REUSEPORT. Defaults to the processor count.
+    /// </summary>
+    public int ReactorCount { get; set; } = Environment.ProcessorCount;
+
+    /// <summary>
+    /// Optional hook to customize the ioxide <see cref="ServerConfig"/> (ring depth, recv buffer ring,
+    /// write slab, zero-copy send, incremental mode, ...). The listen port and reactor count are always
+    /// overridden afterwards by the bound endpoint and <see cref="ReactorCount"/>.
+    /// </summary>
+    public Func<ServerConfig, ServerConfig>? ConfigureServer { get; set; }
+}

--- a/ioxide.Kestrel/README.md
+++ b/ioxide.Kestrel/README.md
@@ -1,0 +1,42 @@
+# ioxide.Kestrel
+
+An ASP.NET Core **Kestrel transport** backed by the [ioxide](https://github.com/MDA2AV/ioxide) io_uring
+runtime. One reactor (io_uring ring) per core, SO_REUSEPORT load-balanced, with Kestrel's entire request
+loop pinned to the reactor thread — no ThreadPool hop on the hot path.
+
+## Usage
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.WebHost.UseIoxide();   // replaces Kestrel's default sockets transport
+
+var app = builder.Build();
+app.MapGet("/", () => "Hello, World!");
+app.Run();
+```
+
+Options:
+
+```csharp
+builder.WebHost.UseIoxide(o =>
+{
+    o.ReactorCount = Environment.ProcessorCount;          // rings/threads (default: ProcessorCount)
+    o.ConfigureServer = cfg => cfg with { RingEntries = 8192 };   // tune the underlying ioxide ServerConfig
+});
+```
+
+## How it works
+
+Each accepted connection is bridged to Kestrel through a `System.IO.Pipelines` duplex whose **reader
+schedulers route continuations onto the owning reactor thread**. A recv pump copies received bytes into
+the inbound pipe and a send pump drains Kestrel's response into the connection's send slab, so
+`recv → HTTP parse → handler → send` all run on a single ring thread.
+
+## Requirements
+
+- Linux with io_uring (kernel 6.x recommended).
+- .NET 11.
+
+> Inline execution note: like any thread-per-core transport, application middleware runs on the reactor
+> thread. Blocking work in a handler stalls every connection on that reactor — keep handlers async.

--- a/ioxide.Kestrel/ReactorPipeScheduler.cs
+++ b/ioxide.Kestrel/ReactorPipeScheduler.cs
@@ -1,0 +1,19 @@
+using System.IO.Pipelines;
+using ioxide;
+
+namespace ioxide.Kestrel;
+
+/// <summary>
+/// A <see cref="PipeScheduler"/> that runs pipe continuations on a reactor's loop thread, so the BCL
+/// pipes in <see cref="HopDuplexPipe"/> keep Kestrel's read → parse → handle → send loop pinned to the
+/// reactor (no ThreadPool hop).
+/// </summary>
+internal sealed class ReactorPipeScheduler : PipeScheduler
+{
+    private readonly Reactor _reactor;
+
+    public ReactorPipeScheduler(Reactor reactor) => _reactor = reactor;
+
+    public override void Schedule(Action<object?> action, object? state)
+        => _reactor.ScheduleOnReactor(action, state);
+}

--- a/ioxide.Kestrel/ioxide.Kestrel.csproj
+++ b/ioxide.Kestrel/ioxide.Kestrel.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net11.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>ioxide.Kestrel</RootNamespace>
+
+    <PackageId>ioxide.Kestrel</PackageId>
+    <Version>0.0.12</Version>
+    <Authors>MDA2AV</Authors>
+    <Description>ASP.NET Core Kestrel transport backed by the ioxide io_uring runtime: one reactor (ring) per core, SO_REUSEPORT load-balanced, with Kestrel's HTTP request loop pinned to the reactor thread. Drop-in via UseIoxide().</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://mda2av.github.io/ioxide/</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/MDA2AV/ioxide</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>io_uring;kestrel;aspnetcore;transport;linux;ioxide;thread-per-core</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="/" />
+    <ProjectReference Include="../ioxide/ioxide.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ioxide.Kestrel/ioxide.Kestrel.csproj
+++ b/ioxide.Kestrel/ioxide.Kestrel.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.Kestrel</RootNamespace>
 
     <PackageId>ioxide.Kestrel</PackageId>
-    <Version>0.0.12</Version>
+    <Version>0.0.13</Version>
     <Authors>MDA2AV</Authors>
     <Description>ASP.NET Core Kestrel transport backed by the ioxide io_uring runtime: one reactor (ring) per core, SO_REUSEPORT load-balanced, with Kestrel's HTTP request loop pinned to the reactor thread. Drop-in via UseIoxide().</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.file/ioxide.file.csproj
+++ b/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.0.12</Version>
+    <Version>0.0.13</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.pg/ioxide.pg.csproj
+++ b/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.0.12</Version>
+    <Version>0.0.13</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.redis/ioxide.redis.csproj
+++ b/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.0.12</Version>
+    <Version>0.0.13</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.slnx
+++ b/ioxide.slnx
@@ -3,6 +3,7 @@
   <Project Path="ioxide.tls/ioxide.tls.csproj" />
   <Project Path="ioxide.redis/ioxide.redis.csproj" />
   <Project Path="ioxide.pg/ioxide.pg.csproj" />
+  <Project Path="ioxide.Kestrel/ioxide.Kestrel.csproj" />
   <Project Path="ioxide/ioxide.csproj" />
   <Project Path="Playground/Playground.csproj" />
   <Project Path="Examples/Examples.csproj" />

--- a/ioxide.slnx
+++ b/ioxide.slnx
@@ -7,5 +7,6 @@
   <Project Path="ioxide/ioxide.csproj" />
   <Project Path="Playground/Playground.csproj" />
   <Project Path="Examples/Examples.csproj" />
+  <Project Path="Examples.AspNet/Examples.AspNet.csproj" />
   <Project Path="Tests/ioxide.e2e.csproj" />
 </Solution>

--- a/ioxide.tls/ioxide.tls.csproj
+++ b/ioxide.tls/ioxide.tls.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.tls</RootNamespace>
 
     <PackageId>ioxide.tls</PackageId>
-    <Version>0.0.12</Version>
+    <Version>0.0.13</Version>
     <Authors>MDA2AV</Authors>
     <Description>TLS for the ioxide io_uring runtime: OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload - handlers keep writing plaintext through the same connection API. Requires Linux kTLS (tls module) and OpenSSL 3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide/Reactor/Reactor.Incremental.cs
+++ b/ioxide/Reactor/Reactor.Incremental.cs
@@ -161,6 +161,7 @@ public sealed unsafe partial class Reactor
             DrainFlushQ();
             DrainRecycleQ();
             DrainRemoteOps();
+            DrainPostQ();
 
             int rc = Ring.SubmitAndWait(1);
             if (rc < 0 && rc != -EINTR && rc != -EAGAIN && rc != -EBUSY)

--- a/ioxide/Reactor/Reactor.Post.cs
+++ b/ioxide/Reactor/Reactor.Post.cs
@@ -1,0 +1,58 @@
+using System.Collections.Concurrent;
+
+namespace ioxide;
+
+// Reactor-thread scheduling, mirroring reedz's IoUringPipeScheduler: a queue of continuations drained
+// each loop iteration, woken via the eventfd (coalesced) only when enqueued from off the reactor.
+// Generalizes the existing _remoteOps/WakeFdWrite machinery to carry arbitrary callbacks, so a Kestrel
+// transport built on BCL pipes can route their reader/writer continuations onto the reactor thread.
+public sealed unsafe partial class Reactor
+{
+    private readonly struct PostItem
+    {
+        public readonly Action<object?> Callback;
+        public readonly object? State;
+        public PostItem(Action<object?> callback, object? state)
+        {
+            Callback = callback;
+            State = state;
+        }
+    }
+
+    private readonly ConcurrentQueue<PostItem> _postQ = new();
+    private int _postSignalPending;   // 0 = no eventfd wake outstanding, 1 = one issued and undrained
+
+    /// <summary>True when the caller is executing on this reactor's loop thread.</summary>
+    public bool OnReactorThread => Environment.CurrentManagedThreadId == _reactorThreadId;
+
+    /// <summary>
+    /// Schedule a continuation to run on the reactor thread. Always enqueues (drained each loop
+    /// iteration by <see cref="DrainPostQ"/>); wakes the loop via the eventfd only when called off the
+    /// reactor, coalescing concurrent producers so at most one wake is outstanding per drain.
+    /// </summary>
+    public void ScheduleOnReactor(Action<object?> callback, object? state)
+    {
+        _postQ.Enqueue(new PostItem(callback, state));
+
+        // On the reactor: the loop will drain before it next parks, so no eventfd write needed.
+        if (Environment.CurrentManagedThreadId == _reactorThreadId)
+        {
+            return;
+        }
+
+        if (Interlocked.Exchange(ref _postSignalPending, 1) == 0)
+        {
+            WakeFdWrite();
+        }
+    }
+
+    private void DrainPostQ()
+    {
+        // Clear before draining so a producer enqueuing during/after the drain still races to wake.
+        Volatile.Write(ref _postSignalPending, 0);
+        while (_postQ.TryDequeue(out PostItem item))
+        {
+            item.Callback(item.State);
+        }
+    }
+}

--- a/ioxide/Reactor/Reactor.cs
+++ b/ioxide/Reactor/Reactor.cs
@@ -444,6 +444,7 @@ public sealed unsafe partial class Reactor
             DrainFlushQ();
             DrainRecycleQ();
             DrainRemoteOps();
+            DrainPostQ();
 
             int rc = Ring.SubmitAndWait(1);
             if (rc < 0 && rc != -EINTR && rc != -EAGAIN && rc != -EBUSY)

--- a/ioxide/ioxide.csproj
+++ b/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.0.12</Version>
+    <Version>0.0.13</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

Adds **`ioxide.Kestrel`** — an ASP.NET Core Kestrel transport backed by ioxide. Each connection runs on an ioxide reactor, and Kestrel's whole request loop (`recv → parse → handler → send`) is **pinned to the reactor thread** — no ThreadPool hop on the hot path. Drop-in via `builder.WebHost.UseIoxide()`.

## Engine impact: minimal and opt-in

Only **3 additive touch points** in the engine, with no behavioral change to the native inline path:

- **`Reactor/Reactor.Post.cs`** (new): `ScheduleOnReactor(Action<object?>, object?)` + `OnReactorThread`, built on the existing `_remoteOps`/`WakeFdWrite` machinery — a queue drained once per loop iteration.
- **`Reactor.cs`** and **`Reactor.Incremental.cs`**: one `DrainPostQ();` per loop.

When nothing uses the scheduler (the native runtime, GenHTTP engine, pg/redis/file clients), `DrainPostQ` is a single `TryDequeue` on an always-empty queue — effectively free, and inline execution is byte-for-byte unchanged. If you don't reference `ioxide.Kestrel`, the engine behaves exactly as before.

## How the transport works

`HopDuplexPipe` hands Kestrel two `System.IO.Pipelines.Pipe`s whose **reader schedulers** are a `ReactorPipeScheduler` (over `Reactor.ScheduleOnReactor`). A recv pump copies received bytes into the inbound pipe and a send pump drains the response into the connection's send slab — both on the reactor. Routing the pipe reader continuations to the reactor is what keeps Kestrel's loop there (it's the one Kestrel-sanctioned hook for loop placement).

## Usage

```csharp
var builder = WebApplication.CreateBuilder(args);
builder.WebHost.UseIoxide();                 // replaces the default sockets transport

var app = builder.Build();
app.MapGet("/", () => "Hello, World!");
app.Run();
```

Options: `UseIoxide(o => { o.ReactorCount = …; o.ConfigureServer = cfg => cfg with { … }; })`.

## Benchmarks (single box, plaintext)

i9-14900K, net11, server pinned to 4 P-cores / 8 reactors, `wrk` on 16 E-cores, median of 3:

| conns | sockets transport | **ioxide.Kestrel** |
|---|---|---|
| 64   | 914K rps (p99 2.65 ms) | **1.36M rps (p99 0.52 ms)** |
| 256  | 915K rps | **1.45M rps** |
| 1024 | 916K rps | **1.37M rps** |

~1.5× the stock sockets transport, with ~100% of request processing on the reactor thread (verified by thread sampling), 0 errors. Caveats: single-box (the load generator shares the machine), small messages, Linux/io_uring only.

## Notes

- New package targets `net11.0`, references `Microsoft.AspNetCore.App`, added to `ioxide.slnx`.
- Public surface is just `UseIoxide()` + `IoxideTransportOptions`; everything else is `internal`.
- Thread-per-core caveat: middleware runs on the reactor thread, so blocking work in a handler stalls every connection on that reactor — keep handlers async.
