### PR TITLE
docs: overview-first example browser; playground readme drops its cod…

### DIFF
--- a/Playground/README.md
+++ b/Playground/README.md
@@ -4,12 +4,8 @@ One project per sample, and **each `Program.cs` is a complete ioxide server you 
 run**. The config, the reactors, the threads, the connection loop and the handler are all there in
 the file — nothing that touches an ioxide API is hidden behind a helper.
 
-```bash
-dotnet run -c Release --project Playground/Tcp/Raw
-curl http://127.0.0.1:8080/
-```
-
-Linux only — the engine is io_uring.
+Run any of them with `dotnet run -c Release --project Playground/<Name>`, then hit
+`http://127.0.0.1:8080/`. Linux only — the engine is io_uring.
 
 ## Samples
 
@@ -47,16 +43,13 @@ shared `ServeAsync` would make the Playground shorter and make it useless.
 
 ## HTTP/3
 
-Both samples answer every request with a single reused response object, so the handler stays
-small enough to read at a glance. `Nghttp3` reads the request body through `BodyReader` while it
-is still arriving; `Nghttp3Buffered` gets it complete in `request.Body`. That one difference is
-the reason both exist.
+Both samples answer every request with a single reused response object, so the handler stays small
+enough to read at a glance. `Nghttp3` reads the request body through `BodyReader` while it is still
+arriving; `Nghttp3Buffered` gets it complete in `request.Body`. That one difference is the reason
+both exist.
 
-They also listen on TCP `:8080` alongside UDP `:8443`.
-
-```bash
-curl --http3-only -k https://127.0.0.1:8443/
-```
+They also listen on TCP `:8080` alongside UDP `:8443`, and answer
+`curl --http3-only -k https://127.0.0.1:8443/`.
 
 ## Environment
 
@@ -91,7 +84,7 @@ descriptors close after a grace period.
 | `PLAYGROUND_QUIC_PORT` | `8443` | UDP listen port. |
 | `PLAYGROUND_QUIC_CERT` | generated | Cert path. Unset generates a self-signed `CN=localhost` pair under the temp directory. |
 | `PLAYGROUND_QUIC_KEY` | generated | Key path. Must be set together with `_CERT`. |
-| `PLAYGROUND_QPACK_CAP` | `0` | QPACK dynamic table capacity, `Nghttp3`/`Nghttp3Buffered` only; `>0` also advertises 100 blocked streams. |
+| `PLAYGROUND_QPACK_CAP` | `0` | QPACK dynamic table capacity; `>0` also advertises 100 blocked streams. |
 
 `SIGTERM` GOAWAYs every live nghttp3 connection, waits 2 s, then exits — without it the process dies
 mid-request and clients see resets. Both samples register that handler themselves, in the file.
@@ -107,11 +100,9 @@ mid-request and clients see resets. Both samples register that handler themselve
 | `PLAYGROUND_PG_POOL` | `4` (per reactor) |
 | `PLAYGROUND_PG_TIMEOUT` | `30000` ms |
 
-```bash
-docker run --rm -d -p 5432:5432 -e POSTGRES_USER=bench -e POSTGRES_DB=bench \
-  -e POSTGRES_HOST_AUTH_METHOD=trust postgres:18
-dotnet run -c Release --project Playground/Pg
-```
+Needs a Postgres to talk to — the defaults match a `postgres:18` container started with
+`POSTGRES_USER=bench`, `POSTGRES_DB=bench` and `POSTGRES_HOST_AUTH_METHOD=trust`. Without one it
+answers `500`, which is the error path working.
 
 ### Proxy
 
@@ -121,21 +112,13 @@ dotnet run -c Release --project Playground/Pg
 | `PLAYGROUND_UPSTREAM_PORT` | `8081` |
 | `PLAYGROUND_UPSTREAM_POOL` | `8` (per reactor) |
 
-```bash
-PLAYGROUND_PORT=8081 dotnet run -c Release --project Playground/Tcp/Raw   # terminal 1: an origin
-dotnet run -c Release --project Playground/Proxy                          # terminal 2: the proxy
-```
+Needs an origin to forward to: run `Tcp.Raw` with `PLAYGROUND_PORT=8081` in one terminal and the
+proxy in another. With nothing listening it answers `502` once the acquire timeout elapses.
 
 ## Docker
 
-One image per sample, selected at build time:
-
-```bash
-docker build -f Playground/Dockerfile --build-arg SAMPLE=Tcp/Raw -t playground-raw .
-docker run --rm -p 8080:8080 playground-raw
-
-docker build -f Playground/Dockerfile --build-arg SAMPLE=Nghttp3 -t playground-h3 .
-docker run --rm -p 8080:8080 -p 8443:8443/udp playground-h3
-```
+`Playground/Dockerfile` builds one image per sample, selected with `--build-arg SAMPLE=<path>` from
+the repo root — `Tcp/Raw`, `Pg`, `Nghttp3` and so on, matching the directory layout. Publish
+`8080/tcp`, and `8443/udp` as well for the HTTP/3 samples.
 
 io_uring pins memory, so a container running many reactors may need `--ulimit memlock=-1:-1`.

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -114,25 +114,39 @@ nav.top .links a.gh svg { display: block; }
   font-size: 1.15rem;
 }
 
-/* ── example browser: menu on the left, code on the right ─────────── */
+/* ── example browser: fixed menu at the far left, code fills the rest ─────────── */
 
-.tabs {
-  margin: 1.4rem 0;
-  display: grid;
-  grid-template-columns: 200px minmax(0, 1fr);
-  gap: 0 1.4rem;
-  align-items: start;
-}
+.tabs { margin: 1.4rem 0; }
 .tabs > input { display: none; }
 
+/* Pinned to the viewport edge and genuinely fixed - it does not travel with the scroll. */
 .ex-menu {
-  grid-column: 1;
-  grid-row: 1;
+  position: fixed;
+  left: 0;
+  top: 5.5rem;
+  z-index: 5;              /* under the sticky top nav */
+  width: 170px;
   display: flex;
   flex-direction: column;
-  border-left: 1px solid var(--line);
-  position: sticky;
-  top: 1rem;
+  padding: 0.9rem 0;
+  background: var(--bg);
+  border-right: 1px solid var(--line);
+  max-height: calc(100vh - 7rem);
+  overflow-y: auto;
+}
+
+.ex-home {
+  font-size: 0.85rem;
+  color: var(--text-dim);
+  padding: 0.42rem 0.6rem 0.42rem 0.85rem;
+  border-left: 2px solid transparent;
+  cursor: pointer;
+}
+.ex-home:hover { color: var(--text); }
+#tab-none:checked ~ .ex-menu .ex-home {
+  color: var(--accent-soft);
+  border-left-color: var(--accent-soft);
+  background: var(--code-bg);
 }
 
 .ex-group {
@@ -143,18 +157,16 @@ nav.top .links a.gh svg { display: block; }
   padding: 1rem 0 0.3rem 0.85rem;
   opacity: 0.85;
 }
-.ex-group:first-of-type { padding-top: 0; }
 
-.ex-menu label {
+.ex-menu label:not(.ex-home) {
   font-size: 0.85rem;
   line-height: 1.3;
   color: var(--text-dim);
   padding: 0.42rem 0.6rem 0.42rem 0.85rem;
-  margin-left: -1px;
   border-left: 2px solid transparent;
   cursor: pointer;
 }
-.ex-menu label:hover { color: var(--text); }
+.ex-menu label:not(.ex-home):hover { color: var(--text); }
 
 #tab-shared:checked ~ .ex-menu label[for="tab-shared"],
 #tab-inc:checked ~ .ex-menu label[for="tab-inc"],
@@ -175,12 +187,19 @@ nav.top .links a.gh svg { display: block; }
   background: var(--code-bg);
 }
 
-.pane {
-  display: none;
-  grid-column: 2;
-  grid-row: 1;
-  min-width: 0;          /* let <pre> scroll instead of stretching the grid */
+/* The overview prose: the default state, replaced the moment an example is picked. */
+.ex-intro { display: none; max-width: 780px; }
+#tab-none:checked ~ .ex-intro { display: block; }
+.ex-intro p { color: var(--text-dim); margin: 0 0 1rem; }
+.ex-intro .lead { font-size: 1.15rem; }
+.ex-hint {
+  font-size: 0.85rem;
+  opacity: 0.7;
+  border-left: 2px solid var(--line);
+  padding-left: 0.8rem;
 }
+
+.pane { display: none; min-width: 0; }
 #tab-shared:checked ~ .pane-shared { display: block; }
 #tab-inc:checked ~ .pane-inc { display: block; }
 #tab-pipe:checked ~ .pane-pipe { display: block; }
@@ -197,27 +216,29 @@ nav.top .links a.gh svg { display: block; }
 #tab-kestrel:checked ~ .pane-kestrel { display: block; }
 .pane pre { margin: 0; }
 
-/* stack the menu above the code on narrow screens */
-@media (max-width: 820px) {
-  .tabs { grid-template-columns: minmax(0, 1fr); gap: 0.9rem; }
+/* Below the menu's width budget it stops being fixed and stacks above the code. */
+@media (max-width: 1320px) {
   .ex-menu {
     position: static;
+    width: auto;
     flex-direction: row;
     flex-wrap: wrap;
     align-items: center;
     gap: 0.15rem;
-    border-left: none;
+    max-height: none;
+    overflow: visible;
+    border-right: none;
     border-bottom: 1px solid var(--line);
-    padding-bottom: 0.5rem;
+    padding: 0 0 0.5rem;
+    margin-bottom: 1.1rem;
   }
-  .ex-group { padding: 0 0.3rem 0 0.5rem; width: 100%; }
-  .ex-group:first-of-type { padding-top: 0; }
+  .ex-group { width: 100%; padding: 0.7rem 0.3rem 0.2rem 0; }
   .ex-menu label {
-    margin-left: 0;
-    border-left: none;
+    border-left: none !important;
     border-bottom: 2px solid transparent;
-    padding: 0.3rem 0.55rem;
+    padding: 0.3rem 0.55rem !important;
   }
+  #tab-none:checked ~ .ex-menu .ex-home,
   #tab-shared:checked ~ .ex-menu label[for="tab-shared"],
   #tab-inc:checked ~ .ex-menu label[for="tab-inc"],
   #tab-pipe:checked ~ .ex-menu label[for="tab-pipe"],
@@ -232,10 +253,8 @@ nav.top .links a.gh svg { display: block; }
   #tab-files:checked ~ .ex-menu label[for="tab-files"],
   #tab-tls:checked ~ .ex-menu label[for="tab-tls"],
   #tab-kestrel:checked ~ .ex-menu label[for="tab-kestrel"] {
-    border-left-color: transparent;
     border-bottom-color: var(--accent-soft);
   }
-  .pane { grid-column: 1; grid-row: 2; }
 }
 
 /* the explainer pane: same panel chrome as the code blocks */
@@ -256,6 +275,24 @@ nav.top .links a.gh svg { display: block; }
 
 /* sections */
 section.block { max-width: 980px; margin: 0 auto; padding: 3.5rem 1.5rem; }
+
+/* The examples section spans the page instead of the centred column, so the code block gets the
+   width. Its left padding clears the fixed menu; below 1180px the menu goes back into the flow
+   and this reverts to the normal centred section. */
+section.block.examples {
+  max-width: none;
+  margin: 0;
+  padding-left: calc(170px + 2.5rem);
+  padding-right: 2.5rem;
+}
+@media (max-width: 1320px) {
+  section.block.examples {
+    max-width: 980px;
+    margin: 0 auto;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+}
 section.block h2 { font-size: 1.7rem; letter-spacing: -0.02em; margin-bottom: 0.4rem; }
 section.block > p.lead { color: var(--text-dim); max-width: 700px; margin-bottom: 1.5rem; }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,17 +28,11 @@
   </p>
 </div>
 
-<section class="block">
+<section class="block examples">
   <h2>A normal async handler. An abnormal runtime under it.</h2>
-  <p class="lead">You write ordinary C#. Underneath, every await is a request placed on this
-  core's queue, and your code resumes right where it left off when the kernel answers. The same
-  model rides TCP and QUIC (ngtcp2 + picotls bundled in the package, TLS 1.3 inside the
-  transport) - pick a transport and a surface, pipes first. HTTP/3 ships as a layer over the
-  QUIC surface. The <em>clients</em> go the other way: a Postgres query, a Redis command, an
-  outbound HTTP call or a file read is submitted on the <em>same</em> ring that accepted the
-  request, and resumes on the same thread - so a request never leaves the core it arrived on.</p>
 <div class="tabs">
-  <input type="radio" name="mode-tabs" id="tab-pipe" checked>
+  <input type="radio" name="mode-tabs" id="tab-none" checked>
+  <input type="radio" name="mode-tabs" id="tab-pipe">
   <input type="radio" name="mode-tabs" id="tab-shared">
   <input type="radio" name="mode-tabs" id="tab-inc">
   <input type="radio" name="mode-tabs" id="tab-vs">
@@ -53,6 +47,8 @@
   <input type="radio" name="mode-tabs" id="tab-tls">
   <input type="radio" name="mode-tabs" id="tab-kestrel">
   <nav class="ex-menu" aria-label="Examples">
+    <label class="ex-home" for="tab-none">overview</label>
+
     <span class="ex-group">tcp</span>
     <label for="tab-pipe">pipes</label>
     <label for="tab-shared">raw &middot; shared ring</label>
@@ -77,6 +73,33 @@
     <label for="tab-tls">ktls</label>
     <label for="tab-kestrel">asp.net</label>
   </nav>
+
+  <div class="ex-intro">
+    <p class="lead">You write ordinary C#. Underneath, every await is a request placed on this
+    core's queue, and your code resumes right where it left off when the kernel answers. The same
+    model rides TCP and QUIC (ngtcp2 + picotls bundled in the package, TLS 1.3 inside the
+    transport) - pick a transport and a surface, pipes first. HTTP/3 ships as a layer over the
+    QUIC surface. The <em>clients</em> go the other way: a Postgres query, a Redis command, an
+    outbound HTTP call or a file read is submitted on the <em>same</em> ring that accepted the
+    request, and resumes on the same thread - so a request never leaves the core it arrived on.</p>
+
+    <p>Each of those awaits is backed by a reusable <code>IValueTaskSource</code>: submitting the
+    op parks your continuation, and the moment its completion arrives the reactor calls
+    <code>SetResult</code> - which runs your code immediately, on the same thread, with nothing
+    scheduled anywhere.</p>
+
+    <p>Every example on the left is runnable code. The
+    <a href="https://github.com/MDA2AV/ioxide/tree/main/Examples">Examples project</a> builds the
+    raw, pg, redis, file and tls variants plus a <code>quic-h3</code> mode that serves HTTP/3 and a
+    pipe echo off one listener, with
+    <a href="https://github.com/MDA2AV/ioxide/blob/main/Examples/RESULTS.md">benchmark results</a>.
+    The <a href="https://github.com/MDA2AV/ioxide/tree/main/Playground">Playground</a> is one
+    self-contained project per workload - a complete server per file, copy-pasteable - and
+    <a href="https://github.com/MDA2AV/ioxide/tree/main/Examples.AspNet">Examples.AspNet</a> is the
+    <code>UseIoxide()</code> drop-in against a stock Kestrel baseline.</p>
+
+    <p class="ex-hint">Pick one to see the code.</p>
+  </div>
   <div class="pane pane-pipe">
 <pre><code class="language-csharp">var config = new ServerConfig
 {
@@ -785,21 +808,6 @@ app.Run();
 // model binding and the rest of the framework, the same engine runs underneath it.</code></pre>
   </div>
 </div>
-  <p>Each of those awaits is backed by a reusable <code>IValueTaskSource</code>: submitting the
-  op parks your continuation, and the moment its completion arrives the reactor calls
-  <code>SetResult</code> - which runs your code immediately, on the same thread, with nothing
-  scheduled anywhere.</p>
-
-  <p>Every tab is runnable code. The
-  <a href="https://github.com/MDA2AV/ioxide/tree/main/Examples">Examples project</a> builds the
-  raw, pg, redis, file and tls variants plus a <code>quic-h3</code> mode that serves HTTP/3 and a
-  pipe echo off one listener, with
-  <a href="https://github.com/MDA2AV/ioxide/blob/main/Examples/RESULTS.md">benchmark results</a>.
-  The <a href="https://github.com/MDA2AV/ioxide/tree/main/Playground">Playground</a> is one
-  self-contained project per workload - a complete server per file, copy-pasteable - and
-  <a href="https://github.com/MDA2AV/ioxide/tree/main/Examples.AspNet">Examples.AspNet</a> is the
-  <code>UseIoxide()</code> drop-in against a stock Kestrel baseline.</p>
-
 </section>
 
 <footer>


### PR DESCRIPTION
…e blocks

The landing page's framing prose - the async-model lead, the IValueTaskSource paragraph and the "where to find this as runnable code" paragraph - now IS the default state of the example browser, and is replaced by the code the moment an example is chosen. Adds a tab-none radio that owns no pane plus an "overview" entry at the top of the menu, so the prose is reachable again after browsing.

The menu is fixed to the viewport's left edge rather than sticky, so it does not travel with the scroll at all. The examples section drops the centred 980px column and spans the page with left padding clearing the menu, which is where the extra code width comes from. The menu is 170px so it clears the centred hero from 1320px up - exactly (1320-980)/2 - and below that it returns to the flow as a wrapped row above the code.

Playground/README.md loses its last five shell blocks. It is prose and tables now: how to run each sample is a sentence, and the code is in the samples where it can be compiled rather than in a README where it can only rot. The root README keeps its C# examples - those are the API tour that was asked for separately.