### PR TITLE
fix(httpclient): h3 1xx interim no longer corrupts the final response

### DIFF
--- a/src/clients/ioxide.httpclient/Http/ResponseAssembly.cs
+++ b/src/clients/ioxide.httpclient/Http/ResponseAssembly.cs
@@ -1,0 +1,54 @@
+namespace ioxide.httpclient;
+
+/// <summary>
+/// Where a response's body starts inside the arena, and what to do when a field section turns out
+/// to be an interim (1xx) head rather than the real one.
+///
+/// h2 and h3 both assemble a response as "one or more field sections, then body bytes" into a
+/// single growable arena, so only the callback plumbing differs between them - the offset rule is
+/// the same. It used to be written out in both files, which is how h3 came to be missing the
+/// interim case that h2 already handled.
+/// </summary>
+internal struct ResponseAssembly
+{
+    /// <summary>First field section seen; a later one is trailers.</summary>
+    public bool HeadersDone;
+
+    /// <summary>Arena offset the body starts at.</summary>
+    public int BodyStart;
+
+    /// <summary>Body bytes accumulated so far.</summary>
+    public int BodyLength;
+
+    /// <summary>
+    /// Record the end of a field section. Returns true when it was an INTERIM (1xx) head - 103
+    /// Early Hints, 100 Continue - which has now been discarded, meaning the real response is
+    /// still to come on the same stream.
+    /// </summary>
+    public bool EndFieldSection(HttpClientResponse response)
+    {
+        // Keeping an interim section's bytes would leave BodyStart pointing at its headers, so the
+        // final response's own headers would be handed back as the body.
+        if (response.Status is >= 100 and < 200)
+        {
+            response.ResetForInterim();
+            HeadersDone = false;
+            BodyStart = 0;
+            BodyLength = 0;
+            return true;
+        }
+
+        if (!HeadersDone)
+        {
+            HeadersDone = true;
+            BodyStart = response.ArenaLength;   // body bytes follow the header bytes
+        }
+
+        // A later section is TRAILERS: leaving BodyStart alone keeps the body range valid, where
+        // moving it would slice past the body into the trailer bytes.
+        return false;
+    }
+
+    /// <summary>The body's slice of the arena, for <see cref="HttpClientResponse.SetBodyRange"/>.</summary>
+    public readonly (int Offset, int Length) BodyRange => (BodyStart, BodyLength);
+}

--- a/src/clients/ioxide.httpclient/Http2/Http2ClientConnection.cs
+++ b/src/clients/ioxide.httpclient/Http2/Http2ClientConnection.cs
@@ -479,25 +479,7 @@ public sealed class Http2ClientConnection : IDisposable
             return;
         }
 
-        // 1xx is INTERIM (103 Early Hints, 100 Continue): the real response follows in another
-        // HEADERS section on the same stream. Keeping this section's bytes would leave BodyStart
-        // pointing at the interim headers, so the final response's headers would be returned as
-        // the body. Drop it and wait for the real one.
-        if (response.Status is >= 100 and < 200)
-        {
-            response.ResetForInterim();
-            pending.HeadersDone = false;
-            pending.BodyStart = 0;
-            pending.BodyLength = 0;
-            return;
-        }
-
-        if (!pending.HeadersDone)
-        {
-            pending.HeadersDone = true;
-            pending.BodyStart = response.ArenaLength;   // body bytes follow the header bytes
-        }
-        // A later section is TRAILERS: leaving BodyStart alone keeps the body range valid.
+        pending.Assembly.EndFieldSection(response);
     }
 
     [UnmanagedCallersOnly]
@@ -508,7 +490,7 @@ public sealed class Http2ClientConnection : IDisposable
             pending.Response is { } response)
         {
             response.Append(new ReadOnlySpan<byte>(data, (int)dataLen));
-            pending.BodyLength += (int)dataLen;
+            pending.Assembly.BodyLength += (int)dataLen;
         }
     }
 
@@ -522,7 +504,7 @@ public sealed class Http2ClientConnection : IDisposable
         }
 
         HttpClientResponse response = pending.Response ?? new HttpClientResponse();
-        response.SetBodyRange((pending.BodyStart, pending.BodyLength));
+        response.SetBodyRange(pending.Assembly.BodyRange);
         response.Freeze();
 
         // Record only - resumed by CompleteFinishedRequests once nghttp2 unwinds.
@@ -590,9 +572,7 @@ public sealed class Http2ClientConnection : IDisposable
         };
 
         public HttpClientResponse? Response;
-        public bool HeadersDone;
-        public int BodyStart;
-        public int BodyLength;
+        public ResponseAssembly Assembly;
 
         public ValueTask<HttpClientResponse> Task => new(this, _core.Version);
 

--- a/src/clients/ioxide.httpclient/Http3/Http3ClientConnection.cs
+++ b/src/clients/ioxide.httpclient/Http3/Http3ClientConnection.cs
@@ -563,14 +563,13 @@ public sealed class Http3ClientConnection : IDisposable
     private static unsafe void CallbackEndHeaders(void* user, long streamId, int fin)
     {
         Http3ClientConnection connection = From(user);
-        if (connection._pending.TryGetValue(streamId, out PendingRequest? pending) &&
-            pending.Response is { } response && !pending.HeadersDone)
+        if (!connection._pending.TryGetValue(streamId, out PendingRequest? pending) ||
+            pending.Response is not { } response)
         {
-            pending.HeadersDone = true;
-            pending.BodyStart = response.ArenaLength;   // body bytes follow the header bytes
+            return;
         }
-        // A second field section is TRAILERS: leaving BodyStart alone keeps the body range valid
-        // (moving it here would slice past the body into the trailer bytes).
+
+        pending.Assembly.EndFieldSection(response);
     }
 
     [UnmanagedCallersOnly]
@@ -581,7 +580,7 @@ public sealed class Http3ClientConnection : IDisposable
             pending.Response is { } response)
         {
             response.Append(new ReadOnlySpan<byte>(data, (int)dataLength));
-            pending.BodyLength += (int)dataLength;
+            pending.Assembly.BodyLength += (int)dataLength;
         }
     }
 
@@ -595,7 +594,7 @@ public sealed class Http3ClientConnection : IDisposable
         }
 
         HttpClientResponse response = pending.Response ?? new HttpClientResponse();
-        response.SetBodyRange((pending.BodyStart, pending.BodyLength));
+        response.SetBodyRange(pending.Assembly.BodyRange);
         response.Freeze();
 
         // Record only - the waiter is resumed by CompleteFinishedRequests once nghttp3 unwinds,
@@ -621,9 +620,7 @@ public sealed class Http3ClientConnection : IDisposable
 
         public HttpClientResponse? Response;
         public long StreamId;
-        public bool HeadersDone;   // first field section seen; a later one is trailers
-        public int BodyStart;
-        public int BodyLength;
+        public ResponseAssembly Assembly;
 
         public ValueTask<HttpClientResponse> Task => new(this, _core.Version);
 

--- a/tests/Ioxide.Tests.Unit/Program.cs
+++ b/tests/Ioxide.Tests.Unit/Program.cs
@@ -14,6 +14,7 @@ internal static class Program
         DemuxParseTests.Register(runner);
         AltSvcTests.Register(runner);
         MessageTests.Register(runner);
+        ResponseAssemblyTests.Register(runner);
 
         return runner.Summary();
     }

--- a/tests/Ioxide.Tests.Unit/ResponseAssemblyTests.cs
+++ b/tests/Ioxide.Tests.Unit/ResponseAssemblyTests.cs
@@ -1,0 +1,140 @@
+using System.Text;
+using ioxide.httpclient;
+
+namespace Ioxide.Tests;
+
+/// <summary>
+/// ResponseAssembly decides where a response's body begins inside the arena. h2 and h3 both drive
+/// it from their header/data callbacks, so getting it wrong does not throw - it silently hands back
+/// the wrong bytes as the body, which is the worst failure mode a client has.
+///
+/// The sequences below are the ones the wire actually produces: one field section then a body, an
+/// interim (1xx) section before the real one, and trailers after the body.
+/// </summary>
+internal static class ResponseAssemblyTests
+{
+    public static void Register(Runner runner)
+    {
+        runner.Test("assembly: body starts after the header bytes", () =>
+        {
+            using var response = new HttpClientResponse();
+            var assembly = new ResponseAssembly();
+
+            AppendHeader(response, "content-type"u8, "text/plain"u8);
+            response.Status = 200;
+
+            Assert.True(!assembly.EndFieldSection(response), "200 is final, not interim");
+
+            int headerBytes = response.ArenaLength;
+            Assert.Equal(headerBytes, assembly.BodyStart);
+
+            AppendBody(response, ref assembly, "hello"u8);
+
+            Assert.Equal((headerBytes, 5), assembly.BodyRange);
+            Assert.Equal("hello", BodyText(response, assembly));
+        });
+
+        runner.Test("assembly: a 1xx interim is discarded and the real body still slices right", () =>
+        {
+            // The regression that motivated this type: h3 treated the final response's field
+            // section as trailers because the interim had already set HeadersDone, leaving
+            // BodyStart inside the final headers. The body then came back as header bytes.
+            using var response = new HttpClientResponse();
+            var assembly = new ResponseAssembly();
+
+            // 103 Early Hints, with a header long enough that a stale BodyStart is unmistakable.
+            AppendHeader(response, "link"u8, "</style.css>; rel=preload"u8);
+            response.Status = 103;
+
+            Assert.True(assembly.EndFieldSection(response), "1xx must report as interim");
+            Assert.Equal(0, response.ArenaLength);
+            Assert.Equal(0, response.Status);
+            Assert.Equal(0, assembly.BodyStart);
+            Assert.True(!assembly.HeadersDone, "the interim section must not count as the headers");
+
+            // The real response follows on the same stream.
+            AppendHeader(response, "content-type"u8, "text/plain"u8);
+            response.Status = 200;
+
+            Assert.True(!assembly.EndFieldSection(response), "200 is final");
+            Assert.Equal(response.ArenaLength, assembly.BodyStart);
+
+            AppendBody(response, ref assembly, "real body"u8);
+            response.Freeze();
+
+            Assert.Equal("real body", BodyText(response, assembly));
+            Assert.Equal(1, response.Headers.Count);
+            Assert.Equal("content-type", Text(response.Headers[0].Key));
+        });
+
+        runner.Test("assembly: several interims in a row all get dropped", () =>
+        {
+            // 100 Continue then 103 Early Hints before the real response is legal, and each one
+            // has to reset rather than accumulate.
+            using var response = new HttpClientResponse();
+            var assembly = new ResponseAssembly();
+
+            foreach (int interim in (int[])[100, 103, 103])
+            {
+                AppendHeader(response, "x-hint"u8, "value"u8);
+                response.Status = interim;
+                Assert.True(assembly.EndFieldSection(response), $"{interim} must report as interim");
+                Assert.Equal(0, response.ArenaLength);
+            }
+
+            AppendHeader(response, "server"u8, "ioxide"u8);
+            response.Status = 204;
+            Assert.True(!assembly.EndFieldSection(response), "204 is final");
+
+            AppendBody(response, ref assembly, "x"u8);
+            Assert.Equal("x", BodyText(response, assembly));
+        });
+
+        runner.Test("assembly: trailers after the body leave the body range alone", () =>
+        {
+            // A second field section AFTER a final response is trailers. Moving BodyStart there
+            // would slice past the body into the trailer bytes.
+            using var response = new HttpClientResponse();
+            var assembly = new ResponseAssembly();
+
+            AppendHeader(response, "content-type"u8, "text/plain"u8);
+            response.Status = 200;
+            assembly.EndFieldSection(response);
+
+            AppendBody(response, ref assembly, "chunked payload"u8);
+            (int Offset, int Length) afterBody = assembly.BodyRange;
+
+            // Trailer section arrives on the same stream.
+            AppendHeader(response, "x-checksum"u8, "deadbeef"u8);
+            Assert.True(!assembly.EndFieldSection(response), "trailers are not interim");
+
+            Assert.Equal(afterBody, assembly.BodyRange);
+            Assert.Equal("chunked payload", BodyText(response, assembly));
+        });
+    }
+
+    private static void AppendHeader(HttpClientResponse response, ReadOnlySpan<byte> name,
+        ReadOnlySpan<byte> value)
+    {
+        (int Offset, int Length) nameRange = response.Append(name);
+        (int Offset, int Length) valueRange = response.Append(value);
+        response.AddHeaderRange(nameRange, valueRange);
+    }
+
+    // What the DATA callbacks do: bytes into the arena, length onto the running body count.
+    private static void AppendBody(HttpClientResponse response, ref ResponseAssembly assembly,
+        ReadOnlySpan<byte> data)
+    {
+        response.Append(data);
+        assembly.BodyLength += data.Length;
+    }
+
+    private static string BodyText(HttpClientResponse response, ResponseAssembly assembly)
+    {
+        response.SetBodyRange(assembly.BodyRange);
+        response.Freeze();
+        return Encoding.ASCII.GetString(response.Body.Span);
+    }
+
+    private static string Text(ReadOnlyMemory<byte> value) => Encoding.ASCII.GetString(value.Span);
+}


### PR DESCRIPTION
Closes #131.

## The bug

nghttp3 delivers an interim (1xx) response as its own field section, then fires a second one for the real response on the same stream. `CallbackEndHeaders` only acted on the *first* section it saw:

- the interim set `HeadersDone` and pinned `BodyStart` just past the interim's header bytes;
- the real response's section was then taken for trailers, so `BodyStart` was left where the interim put it.

The body range therefore began inside the final response's own header bytes, and the interim's header ranges survived in the arena to be merged into `Headers` at `Freeze`. A server sending `103 Early Hints` (or `100 Continue`) got a corrupted body and a header list with the hints spliced in.

## The fix

h2 already handled this correctly. The rule was written out longhand in both `Http2ClientConnection` and `Http3ClientConnection`, which is precisely how h3 came to be missing it, so it now lives once in `Http/ResponseAssembly.cs` and both connections drive that:

- where the body starts in the arena (`BodyStart`/`BodyLength`/`BodyRange`),
- and the interim-discard decision taken at the end of every field section.

Behaviour for h2 is unchanged; it is the same logic, relocated.

## Tests

Four unit tests in `ResponseAssemblyTests` over the sequences the wire actually produces: body after headers, a 1xx followed by the real response, several interims in a row, and trailers after the body.

Verified they can fail — deleting the interim branch fails two of them:

```
FAIL  assembly: a 1xx interim is discarded and the real body still slices right: 1xx must report as interim
FAIL  assembly: several interims in a row all get dropped: 100 must report as interim
18 passed, 2 failed
```

Full `Ioxide.Tests.Http` suite green with the nginx h2c sidecar running, so the relocated h2 path is executed rather than skipped: **18 passed, 0 failed, 0 skipped**.

---

## Correction after review

The tests pin the **extracted rule**, not the h3 wiring. Reverting `Http3ClientConnection`'s call site to the old `!pending.HeadersDone` guard passes the entire suite — nothing verifies that nghttp3 actually routes through `EndFieldSection`.

Issue #131 asked for a pool test with an origin sending 103 before the 200. That was not written, because our h3 server has no `submit_info` in its shim and adding one to test a client fix is scope this PR should not take. So the shared rule is well covered and the h3 integration is not; the fix is still correct by inspection and by parity with h2, which the same rule now drives.
