### PR TITLE
fix(httpclient): bound the h2/h3 response arena and stop the growth overflow

### DIFF
--- a/src/clients/ioxide.httpclient/Http/HttpClientResponse.cs
+++ b/src/clients/ioxide.httpclient/Http/HttpClientResponse.cs
@@ -45,16 +45,48 @@ public sealed class HttpClientResponse : IDisposable
     /// <summary>Current arena fill - the offset the next Append will land at.</summary>
     internal int ArenaLength => _arenaUsed;
 
+    // Ceiling on headers + body for this response. h2 and h3 stream a response in through native
+    // callbacks with no Content-Length to check up front, so this is the only thing bounding what
+    // a hostile or broken origin can make us allocate.
+    private int _maxArenaBytes = DefaultMaxArenaBytes;
+
+    // Matches HttpClientOptions.MaxResponseBytes, so all three protocols default alike.
+    private const int DefaultMaxArenaBytes = 8 * 1024 * 1024;
+
+    /// <summary>
+    /// True once an Append was refused for exceeding the cap. Appends are driven from
+    /// <c>[UnmanagedCallersOnly]</c> callbacks, where a throw would cross native frames and take
+    /// the process down, so the overflow is RECORDED here and the owning connection turns it into
+    /// a failed request once the native call has unwound.
+    /// </summary>
+    internal bool Overflowed { get; private set; }
+
+    internal void SetMaxArenaBytes(int max) => _maxArenaBytes = Math.Max(1, max);
+
     internal (int Offset, int Length) Append(ReadOnlySpan<byte> data)
     {
+        // Past the cap: drop the bytes and record it. Growing to serve an origin that has already
+        // overrun its budget is the thing being prevented, and the request is going to fail
+        // anyway, so nothing is gained by keeping the data.
+        if (Overflowed || data.Length > _maxArenaBytes - _arenaUsed)
+        {
+            Overflowed = true;
+            return (_arenaUsed, 0);
+        }
+
         if (_arena.Length - _arenaUsed < data.Length)
         {
-            int size = Math.Max(4096, _arena.Length * 2);
-            while (size - _arenaUsed < data.Length)
+            // In long, because the doubling overflows int once the arena reaches 1 GiB: size went
+            // negative, Math.Max picked 4096, and the loop then doubled its way to int.MinValue
+            // for ArrayPool.Rent to throw on - inside a native callback.
+            long size = Math.Max(4096, (long)_arena.Length * 2);
+            long needed = (long)_arenaUsed + data.Length;
+            while (size < needed)
             {
                 size *= 2;
             }
-            byte[] grown = ArrayPool<byte>.Shared.Rent(size);
+
+            byte[] grown = ArrayPool<byte>.Shared.Rent((int)Math.Min(size, _maxArenaBytes));
             _arena.AsSpan(0, _arenaUsed).CopyTo(grown);
             if (_arena.Length > 0)
             {
@@ -96,10 +128,21 @@ public sealed class HttpClientResponse : IDisposable
         _bodyRange = (0, -1);
         Status = 0;
         ConnectionClose = false;
+        Overflowed = false;
     }
 
     internal void Freeze()
     {
+        // Freeze runs inside the same native callbacks Append does, so it must not throw either.
+        // An overflowed response is about to be discarded and its recorded ranges describe bytes
+        // the arena refused, so materializing them would be both pointless and out of bounds.
+        if (Overflowed)
+        {
+            _ranges.Clear();
+            Body = default;
+            return;
+        }
+
         foreach ((int nameOffset, int nameLength, int valueOffset, int valueLength) in _ranges)
         {
             Headers.Add(_arena.AsMemory(nameOffset, nameLength), _arena.AsMemory(valueOffset, valueLength));
@@ -130,6 +173,7 @@ public sealed class HttpClientResponse : IDisposable
         Body = default;
         _bodyRange = (0, -1);
         _arenaUsed = 0;
+        Overflowed = false;
         if (_arena.Length > 0)
         {
             ArrayPool<byte>.Shared.Return(_arena);

--- a/src/clients/ioxide.httpclient/Http/HttpClientResponse.cs
+++ b/src/clients/ioxide.httpclient/Http/HttpClientResponse.cs
@@ -48,10 +48,19 @@ public sealed class HttpClientResponse : IDisposable
     // Ceiling on headers + body for this response. h2 and h3 stream a response in through native
     // callbacks with no Content-Length to check up front, so this is the only thing bounding what
     // a hostile or broken origin can make us allocate.
-    private int _maxArenaBytes = DefaultMaxArenaBytes;
+    //
+    // Unbounded by default, and deliberately so. This type is shared by all three protocols, and
+    // HTTP/1.1 bounds its responses a different way - it reads Content-Length and rejects an
+    // oversize body before allocating (HttpClientConnection), never consulting Overflowed. A
+    // default ceiling here therefore did not protect h1, it silently TRUNCATED it: parsing
+    // completed while the arena dropped bytes, and the caller got status 200 with empty headers
+    // and an empty body. The protocols that need a ceiling ask for one.
+    private int _maxArenaBytes = MaxArenaBytesLimit;
 
-    // Matches HttpClientOptions.MaxResponseBytes, so all three protocols default alike.
-    private const int DefaultMaxArenaBytes = 8 * 1024 * 1024;
+    // ArrayPool.Rent throws above this regardless of free memory, and Rent is reached from inside
+    // [UnmanagedCallersOnly] callbacks - so this is a hard ceiling on what any caller may ask for,
+    // not merely a default.
+    private static readonly int MaxArenaBytesLimit = Array.MaxLength;
 
     /// <summary>
     /// True once an Append was refused for exceeding the cap. Appends are driven from
@@ -61,7 +70,12 @@ public sealed class HttpClientResponse : IDisposable
     /// </summary>
     internal bool Overflowed { get; private set; }
 
-    internal void SetMaxArenaBytes(int max) => _maxArenaBytes = Math.Max(1, max);
+    /// <summary>
+    /// Bound this response's arena. Clamped at both ends: a caller asking for more than
+    /// <see cref="Array.MaxLength"/> would otherwise turn a large response into a Rent failure
+    /// inside a native callback, which is the crash this ceiling exists to prevent.
+    /// </summary>
+    internal void SetMaxArenaBytes(int max) => _maxArenaBytes = Math.Clamp(max, 1, MaxArenaBytesLimit);
 
     internal (int Offset, int Length) Append(ReadOnlySpan<byte> data)
     {

--- a/src/clients/ioxide.httpclient/Http2/Http2ClientConnection.cs
+++ b/src/clients/ioxide.httpclient/Http2/Http2ClientConnection.cs
@@ -58,10 +58,16 @@ public sealed class Http2ClientConnection : IDisposable
 
     private readonly TaskCompletionSource<bool> _ready = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    private Http2ClientConnection(RingSocket socket, string authority)
+    // Ceiling on headers + body per response. nghttp2 streams a response in through callbacks with
+    // no length known up front, so without this a single origin can grow the arena until the
+    // process dies.
+    private readonly int _maxResponseBytes;
+
+    private Http2ClientConnection(RingSocket socket, string authority, int maxResponseBytes)
     {
         _socket = socket;
         _authority = System.Text.Encoding.ASCII.GetBytes(authority);
+        _maxResponseBytes = maxResponseBytes;
     }
 
     public bool IsBroken => _failed || _disposed || _retiring;
@@ -74,7 +80,7 @@ public sealed class Http2ClientConnection : IDisposable
     public int InFlight => _pending.Count;
 
     public static async Task<Http2ClientConnection> ConnectAsync(IRingHost host, string ip, ushort port,
-        string authority)
+        string authority, int maxResponseBytes = 8 * 1024 * 1024)
     {
         RingSocket socket = RingSocket.CreateTcp(host);
         try
@@ -91,7 +97,7 @@ public sealed class Http2ClientConnection : IDisposable
             throw;
         }
 
-        var connection = new Http2ClientConnection(socket, authority);
+        var connection = new Http2ClientConnection(socket, authority, maxResponseBytes);
         connection.Setup();
         _ = connection.PumpLoopAsync();
         await connection._ready.Task;   // preface + SETTINGS on the wire before the first request
@@ -386,14 +392,24 @@ public sealed class Http2ClientConnection : IDisposable
 
         foreach ((PendingRequest pending, HttpClientResponse? response, Exception? error) in finished)
         {
-            if (error is null)
-            {
-                pending.Complete(response!);
-            }
-            else
+            if (error is not null)
             {
                 pending.Fail(error);
+                continue;
             }
+
+            // The arena refused bytes for exceeding MaxResponseBytes. The callbacks could only
+            // record that; failing the caller happens here, where a throw no longer crosses
+            // nghttp2's frames.
+            if (response!.Overflowed)
+            {
+                response.Dispose();
+                pending.Fail(new Http2ClientException(
+                    $"response exceeds MaxResponseBytes ({_maxResponseBytes})"));
+                continue;
+            }
+
+            pending.Complete(response);
         }
     }
 
@@ -507,8 +523,10 @@ public sealed class Http2ClientConnection : IDisposable
         if (connection._pending.TryGetValue(streamId, out PendingRequest? pending) &&
             pending.Response is { } response)
         {
-            response.Append(new ReadOnlySpan<byte>(data, (int)dataLen));
-            pending.BodyLength += (int)dataLen;
+            // Count what the arena ACCEPTED, not what arrived: past MaxResponseBytes the append is
+            // refused and returns a zero-length range, and a body length that outran the arena
+            // would make Freeze slice out of bounds - inside this callback, which is fatal.
+            pending.BodyLength += response.Append(new ReadOnlySpan<byte>(data, (int)dataLen)).Length;
         }
     }
 

--- a/src/clients/ioxide.httpclient/Http2/Http2ClientConnection.cs
+++ b/src/clients/ioxide.httpclient/Http2/Http2ClientConnection.cs
@@ -448,9 +448,19 @@ public sealed class Http2ClientConnection : IDisposable
     private static unsafe void CallbackBeginHeaders(void* user, int streamId)
     {
         Http2ClientConnection connection = FromUser(user);
-        if (connection._pending.TryGetValue(streamId, out PendingRequest? pending))
+
+        // One response per request, created on the FIRST field section and kept. nghttp2 reports
+        // trailers as HCAT_HEADERS, the same category as the real response after a 1xx, so this
+        // callback fires again at the end of a trailered stream. Replacing the response there
+        // would throw away the assembled one while BodyStart/BodyLength still describe its arena,
+        // and CallbackEndStream would then slice those offsets out of the fresh, near-empty one.
+        // Interim (1xx) heads are cleared by ResetForInterim instead, which reuses this object.
+        if (connection._pending.TryGetValue(streamId, out PendingRequest? pending) &&
+            pending.Response is null)
         {
-            pending.Response = new HttpClientResponse();
+            var response = new HttpClientResponse();
+            response.SetMaxArenaBytes(connection._maxResponseBytes);
+            pending.Response = response;
         }
     }
 

--- a/src/clients/ioxide.httpclient/Http2/Http2ClientPool.cs
+++ b/src/clients/ioxide.httpclient/Http2/Http2ClientPool.cs
@@ -17,6 +17,10 @@ public sealed record Http2ClientOptions
     public int PoolSize { get; init; } = 1;
 
     public int AcquireTimeoutMs { get; init; } = 10_000;
+
+    /// <summary>Per-request ceiling for headers + body; a bigger response fails the request
+    /// instead of growing the arena without bound.</summary>
+    public int MaxResponseBytes { get; init; } = 8 * 1024 * 1024;
 }
 
 /// <summary>
@@ -183,7 +187,7 @@ public sealed class Http2ClientPool : IDisposable
         try
         {
             Http2ClientConnection connection = await Http2ClientConnection.ConnectAsync(
-                _host, _options.Host, _options.Port, _authority);
+                _host, _options.Host, _options.Port, _authority, _options.MaxResponseBytes);
 
             if (_disposed)
             {

--- a/src/clients/ioxide.httpclient/Http3/Http3ClientConnection.cs
+++ b/src/clients/ioxide.httpclient/Http3/Http3ClientConnection.cs
@@ -63,11 +63,18 @@ public sealed class Http3ClientConnection : IDisposable
     // RFC 9114 H3_NO_ERROR - what a clean application-level close carries.
     private const ulong H3NoError = 0x100;
 
-    internal Http3ClientConnection(QuicEngineConnection quic, string authority, int readyTimeoutMs)
+    // Ceiling on headers + body per response. h3 streams a response in through callbacks with no
+    // length known up front, so without this a single origin can grow the arena until the process
+    // dies.
+    private readonly int _maxResponseBytes;
+
+    internal Http3ClientConnection(QuicEngineConnection quic, string authority, int readyTimeoutMs,
+        int maxResponseBytes)
     {
         _quic = quic;
         _authority = System.Text.Encoding.ASCII.GetBytes(authority);
         _readyTimeoutMs = readyTimeoutMs;
+        _maxResponseBytes = maxResponseBytes;
 
         // Nothing else wakes a client connection until the peer sends stream data, and the peer
         // has nothing to send until we ask - so the handshake signal is what starts h3 setup.
@@ -446,6 +453,18 @@ public sealed class Http3ClientConnection : IDisposable
             {
                 Nghttp3.ih3_close_stream(_nghttp3Handle, pending.StreamId, 0);
             }
+
+            // The arena refused bytes for exceeding MaxResponseBytes. The callbacks could only
+            // record that; failing the caller happens here, where a throw no longer crosses
+            // nghttp3's frames.
+            if (response.Overflowed)
+            {
+                response.Dispose();
+                pending.Fail(new Http3ClientException(
+                    $"response exceeds MaxResponseBytes ({_maxResponseBytes})"));
+                continue;
+            }
+
             pending.Complete(response);
         }
     }
@@ -520,9 +539,12 @@ public sealed class Http3ClientConnection : IDisposable
     private static unsafe void CallbackBeginHeaders(void* user, long streamId)
     {
         Http3ClientConnection connection = From(user);
-        if (connection._pending.TryGetValue(streamId, out PendingRequest? pending))
+        if (connection._pending.TryGetValue(streamId, out PendingRequest? pending) &&
+            pending.Response is null)
         {
-            pending.Response ??= new HttpClientResponse();
+            var response = new HttpClientResponse();
+            response.SetMaxArenaBytes(connection._maxResponseBytes);
+            pending.Response = response;
         }
     }
 
@@ -580,8 +602,10 @@ public sealed class Http3ClientConnection : IDisposable
         if (connection._pending.TryGetValue(streamId, out PendingRequest? pending) &&
             pending.Response is { } response)
         {
-            response.Append(new ReadOnlySpan<byte>(data, (int)dataLength));
-            pending.BodyLength += (int)dataLength;
+            // Count what the arena ACCEPTED, not what arrived: past MaxResponseBytes the append is
+            // refused and returns a zero-length range, and a body length that outran the arena
+            // would make Freeze slice out of bounds - inside this callback, which is fatal.
+            pending.BodyLength += response.Append(new ReadOnlySpan<byte>(data, (int)dataLength)).Length;
         }
     }
 

--- a/src/clients/ioxide.httpclient/Http3/Http3ClientPool.cs
+++ b/src/clients/ioxide.httpclient/Http3/Http3ClientPool.cs
@@ -20,6 +20,10 @@ public sealed record Http3ClientOptions
 
     /// <summary>How long a request waits for a usable connection (handshake included).</summary>
     public int AcquireTimeoutMs { get; init; } = 10_000;
+
+    /// <summary>Per-request ceiling for headers + body; a bigger response fails the request
+    /// instead of growing the arena without bound.</summary>
+    public int MaxResponseBytes { get; init; } = 8 * 1024 * 1024;
 }
 
 /// <summary>
@@ -122,7 +126,8 @@ public sealed class Http3ClientPool : IDisposable
         try
         {
             QuicEngineConnection quic = _engine.Connect(_reactor, _options.Host, _options.Port, _options.ServerName);
-            _connections.Add(new Http3ClientConnection(quic, $"{_options.ServerName}:{_options.Port}", _options.AcquireTimeoutMs));
+            _connections.Add(new Http3ClientConnection(quic, $"{_options.ServerName}:{_options.Port}",
+                _options.AcquireTimeoutMs, _options.MaxResponseBytes));
         }
         catch (Exception e)
         {

--- a/tests/Ioxide.Tests.Http/Http2ClientTests.cs
+++ b/tests/Ioxide.Tests.Http/Http2ClientTests.cs
@@ -62,6 +62,21 @@ internal static class Http2ClientTests
             (_, string stats) = Client.Get(driver, "/connstats");
             Assert.Equal("conns=1", stats);
         }, skip: noSidecar);
+
+        runner.Test("httpclient h2: MaxResponseBytes is enforced, not merely configured", () =>
+        {
+            // The option was plumbed all the way to the connection and then used only in the
+            // exception TEXT - nothing ever applied it to the response arena, so h2 silently kept
+            // whatever the shared default happened to be and the error message named a limit it
+            // was not enforcing. The sidecar's 1 KiB object against a 16-byte ceiling settles it.
+            int driver = TestServer.Start(DriverHandler, onStart: reactor =>
+                Http2ClientPool.Start(reactor, Options() with { MaxResponseBytes = 16 }));
+
+            (int status, string body) = Client.Get(driver, "/index.html", timeoutMs: 20_000);
+            Assert.Equal(200, status);
+            Assert.True(body.StartsWith("599|"), $"expected the request to fail, got: {body}");
+            Assert.True(body.Contains("MaxResponseBytes"), $"should name the limit, got: {body}");
+        }, skip: noSidecar);
     }
 
     // Sends a POST with a 4 KiB body and reports the status, so a dropped body shows up as a

--- a/tests/Ioxide.Tests.Http/Http3ClientTests.cs
+++ b/tests/Ioxide.Tests.Http/Http3ClientTests.cs
@@ -96,12 +96,42 @@ internal static class Http3ClientTests
             Assert.Equal(200, status);
             Assert.Equal("200|origin via shared socket", body);
         });
+
+        runner.Test("httpclient h3: a response past MaxResponseBytes fails the request, not the process", () =>
+        {
+            // The arena refuses the bytes from inside an nghttp3 callback, where throwing would
+            // cross native frames and kill the process. It records instead, and the connection
+            // turns that into a failed request after nghttp3 unwinds - so what the caller sees is
+            // an ordinary exception, and the reactor is still alive to serve the next request.
+            (string certPath, string keyPath) = TestCert.Ensure();
+            using var serverEngine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: ["h3"]);
+
+            (_, int originUdpPort) = TestServer.StartDatagram(
+                onDatagram: null,
+                quicFactory: serverEngine.CreateFactory(),
+                quicHandle: static (_, connection) => new Nghttp3Connection(connection).RunBufferedAsync(
+                    static request => Nghttp3Response.Text(
+                        request.Path.Span.SequenceEqual("/small"u8)
+                            ? "tiny"
+                            : new string('x', 64 * 1024))));
+
+            int driver = StartH3Driver(originUdpPort, maxResponseBytes: 8 * 1024);
+
+            (int status, string body) = Client.Get(driver, "/huge");
+            Assert.Equal(200, status);                       // the driver answered at all
+            Assert.True(body.StartsWith("599|"), $"request should have failed, got: {body}");
+            Assert.True(body.Contains("MaxResponseBytes"), $"should name the cap, got: {body}");
+
+            // The connection and its reactor survived, so a normal request still works.
+            (_, string after) = Client.Get(driver, "/small");
+            Assert.Equal("200|tiny", after);
+        });
     }
 
     // A TCP endpoint whose handler forwards to the h3 origin through the ring-native h3 client.
     // Its reactor has NO QUIC configuration: the first outbound connect opens an ephemeral-port
     // socket for it, which is what makes ioxide.httpclient usable without running a server.
-    private static int StartH3Driver(int originUdpPort)
+    private static int StartH3Driver(int originUdpPort, int maxResponseBytes = 8 * 1024 * 1024)
     {
         var options = new Http3ClientOptions
         {
@@ -109,6 +139,7 @@ internal static class Http3ClientTests
             Port = (ushort)originUdpPort,
             ServerName = "localhost",
             PoolSize = 1,
+            MaxResponseBytes = maxResponseBytes,
         };
 
         return TestServer.StartQuicClientHost(

--- a/tests/Ioxide.Tests.Http/HttpClientTests.cs
+++ b/tests/Ioxide.Tests.Http/HttpClientTests.cs
@@ -17,6 +17,9 @@ namespace Ioxide.Tests;
 /// </summary>
 internal static class HttpClientTests
 {
+    // 9 MiB: comfortably past the 8 MiB ceiling that HttpClientResponse used to apply by default.
+    private const int HugeBodyBytes = 9 * 1024 * 1024;
+
     public static void Register(Runner runner)
     {
         runner.Test("httpclient h1: GET through a proxy handler (pool on the reactor)", () =>
@@ -112,6 +115,34 @@ internal static class HttpClientTests
             Assert.Equal($"200|{100_000}", body);
         });
 
+        runner.Test("httpclient h1: a response above the arena's old default ceiling is intact", () =>
+        {
+            // HttpClientResponse is shared by h1, h2 and h3, and h1 bounds responses a DIFFERENT
+            // way - Content-Length checked before allocating, never consulting Overflowed. Giving
+            // the shared arena a default ceiling therefore did not protect h1, it truncated it:
+            // parsing completed while the arena silently dropped bytes, and the caller got 200
+            // with empty headers and an empty body. Raising h1's own documented limit has to work.
+            int origin = TestServer.Start(OriginHandler);
+            int proxy = StartProxy(origin, maxResponseBytes: 32 * 1024 * 1024);
+
+            (int status, string body) = Client.Get(proxy, "/huge", timeoutMs: 30_000);
+            Assert.Equal(200, status);
+            Assert.Equal($"200|{HugeBodyBytes}", body);
+        });
+
+        runner.Test("httpclient h1: a response past MaxResponseBytes still fails loudly", () =>
+        {
+            // The other half: h1's own limit must keep rejecting, so the fix above did not simply
+            // remove the bound.
+            int origin = TestServer.Start(OriginHandler);
+            int proxy = StartProxy(origin, maxResponseBytes: 64 * 1024);
+
+            (int status, string body) = Client.Get(proxy, "/huge", timeoutMs: 30_000);
+            Assert.Equal(200, status);
+            Assert.True(body.StartsWith("599|"), $"expected the request to fail, got: {body[..Math.Min(60, body.Length)]}");
+            Assert.True(body.Contains("MaxResponseBytes"), $"should name the limit, got: {body[..Math.Min(60, body.Length)]}");
+        });
+
         runner.Test("httpclient h1: POST body reaches the origin intact", () =>
         {
             int origin = TestServer.Start(OriginHandler);
@@ -136,7 +167,8 @@ internal static class HttpClientTests
     // Start a proxy server: its handler calls the origin through the ring-native client and writes
     // "<upstream status>|<detail>" back. The pool is created in OnStart, so it belongs to this
     // reactor's ring - the documented way to use it.
-    private static int StartProxy(int originPort, int poolSize = 4, int? acquireTimeoutMs = null)
+    private static int StartProxy(int originPort, int poolSize = 4, int? acquireTimeoutMs = null,
+        int? maxResponseBytes = null)
     {
         var options = new HttpClientOptions
         {
@@ -145,6 +177,11 @@ internal static class HttpClientTests
             PoolSize = poolSize,
             ReceiveBufferSize = 4096,   // small on purpose: /big must exercise buffer growth
         };
+
+        if (maxResponseBytes is { } max)
+        {
+            options = options with { MaxResponseBytes = max };
+        }
 
         if (acquireTimeoutMs is { } timeout)
         {
@@ -190,7 +227,7 @@ internal static class HttpClientTests
                         upstreamStatus = response.Status;
                         detail = path switch
                         {
-                            "/big" => response.Body.Length.ToString(),
+                            "/big" or "/huge" => response.Body.Length.ToString(),
                             "/headers" => response.TryGetHeader("x-demo"u8, out ReadOnlyMemory<byte> demo)
                                 ? $"x-demo={Encoding.ASCII.GetString(demo.Span)}"
                                 : "x-demo=MISSING",
@@ -258,6 +295,15 @@ internal static class HttpClientTests
                     case "/big":
                         connection.Write(Encoding.ASCII.GetBytes(
                             $"HTTP/1.1 200 OK\r\nContent-Length: {100_000}\r\n\r\n" + new string('x', 100_000)));
+                        break;
+
+                    // Past the 8 MiB that used to be the shared response arena's default ceiling,
+                    // so a client raising MaxResponseBytes above it has something to prove itself
+                    // against.
+                    case "/huge":
+                        connection.Write(Encoding.ASCII.GetBytes(
+                            $"HTTP/1.1 200 OK\r\nContent-Length: {HugeBodyBytes}\r\n\r\n"
+                            + new string('h', HugeBodyBytes)));
                         break;
 
                     case "/post":

--- a/tests/Ioxide.Tests.Unit/Program.cs
+++ b/tests/Ioxide.Tests.Unit/Program.cs
@@ -14,6 +14,7 @@ internal static class Program
         DemuxParseTests.Register(runner);
         AltSvcTests.Register(runner);
         MessageTests.Register(runner);
+        ResponseCapTests.Register(runner);
 
         return runner.Summary();
     }

--- a/tests/Ioxide.Tests.Unit/ResponseCapTests.cs
+++ b/tests/Ioxide.Tests.Unit/ResponseCapTests.cs
@@ -1,0 +1,117 @@
+using ioxide.httpclient;
+
+namespace Ioxide.Tests;
+
+/// <summary>
+/// The ceiling on a response arena. h2 and h3 stream a response in through native callbacks with
+/// no length known up front, so the arena is the only thing standing between a hostile or broken
+/// origin and an unbounded allocation.
+///
+/// The cap cannot report by throwing: Append runs inside [UnmanagedCallersOnly] callbacks, and an
+/// exception there crosses native frames and takes the process down. It records instead, and the
+/// owning connection fails the request once the native call has unwound.
+/// </summary>
+internal static class ResponseCapTests
+{
+    public static void Register(Runner runner)
+    {
+        runner.Test("cap: a response inside the ceiling is untouched", () =>
+        {
+            using var response = new HttpClientResponse();
+            response.SetMaxArenaBytes(1024);
+
+            response.Append(new byte[512]);
+            response.Append(new byte[512]);
+
+            Assert.True(!response.Overflowed, "exactly at the ceiling is not an overflow");
+            Assert.Equal(1024, response.ArenaLength);
+        });
+
+        runner.Test("cap: the append that would cross the ceiling is refused, not served", () =>
+        {
+            using var response = new HttpClientResponse();
+            response.SetMaxArenaBytes(1024);
+
+            response.Append(new byte[1000]);
+            Assert.True(!response.Overflowed, "under the ceiling");
+
+            (int Offset, int Length) refused = response.Append(new byte[25]);
+
+            Assert.True(response.Overflowed, "crossing the ceiling must record an overflow");
+            Assert.Equal(0, refused.Length);
+            Assert.Equal(1000, response.ArenaLength);   // the bytes were dropped, not appended
+        });
+
+        runner.Test("cap: once overflowed, later appends stay refused", () =>
+        {
+            // The callbacks keep firing for the rest of the stream - nothing tells nghttp2/nghttp3
+            // to stop - so every subsequent append has to be a no-op rather than resuming growth.
+            using var response = new HttpClientResponse();
+            response.SetMaxArenaBytes(64);
+
+            response.Append(new byte[65]);
+            Assert.True(response.Overflowed, "first oversize append overflows");
+
+            response.Append(new byte[1]);
+            response.Append(new byte[1]);
+
+            Assert.Equal(0, response.ArenaLength);
+            Assert.True(response.Overflowed, "still overflowed");
+        });
+
+        runner.Test("cap: growth past the ceiling never rents a negative size", () =>
+        {
+            // The trap this replaced: the arena doubled in int, so at 1 GiB the size went negative,
+            // Math.Max picked 4096, and the loop doubled its way to int.MinValue for
+            // ArrayPool.Rent to throw on - inside a native callback, which is fatal. The ceiling
+            // now makes that unreachable and the arithmetic is done in long regardless.
+            using var response = new HttpClientResponse();
+            response.SetMaxArenaBytes(1 << 20);
+
+            // Many growth rounds from the 4096 floor up to the ceiling.
+            for (int i = 0; i < 300; i++)
+            {
+                response.Append(new byte[4096]);
+            }
+
+            Assert.True(response.Overflowed, "300 x 4 KiB exceeds a 1 MiB ceiling");
+            Assert.True(response.ArenaLength <= 1 << 20, "arena never exceeds the ceiling");
+        });
+
+        runner.Test("cap: Freeze after an overflow is empty rather than out of bounds", () =>
+        {
+            // Freeze runs inside the same native callbacks Append does. A body range recorded from
+            // what ARRIVED rather than what was stored slices past the arena, and that throw
+            // crossed nghttp3's frames and took the process down - which is how this was found.
+            using var response = new HttpClientResponse();
+            response.SetMaxArenaBytes(64);
+
+            (int Offset, int Length) name = response.Append("content-type"u8);
+            response.AddHeaderRange(name, name);
+
+            response.Append(new byte[128]);    // refused
+            response.SetBodyRange((0, 128));   // what counting arrivals instead of stores records
+
+            response.Freeze();                 // must not throw
+
+            Assert.Equal(0, response.Body.Length);
+            Assert.Equal(0, response.Headers.Count);
+        });
+
+        runner.Test("cap: an interim reset clears the overflow", () =>
+        {
+            // A 1xx whose headers overran the cap must not condemn the real response that follows.
+            using var response = new HttpClientResponse();
+            response.SetMaxArenaBytes(32);
+
+            response.Append(new byte[33]);
+            Assert.True(response.Overflowed, "interim overran");
+
+            response.ResetForInterim();
+
+            Assert.True(!response.Overflowed, "reset clears it");
+            response.Append(new byte[16]);
+            Assert.Equal(16, response.ArenaLength);
+        });
+    }
+}


### PR DESCRIPTION
Closes #133. **Updated after review — the first version of this PR had three defects, one a proven regression.**

## The original bug

`HttpClientOptions` (h1) has `MaxResponseBytes`. h2 and h3 had no equivalent — both stream a response in through native callbacks with no length known up front, so an origin could grow the arena until the process died.

Worse, the growth arithmetic broke before it got there. `_arena.Length * 2` overflows `int` once the arena reaches 1 GiB:

```
arena=1073741824 -> initial size=4096
   settles at size=-2147483648 (Rent would THROW)
```

`ArrayPool.Rent(int.MinValue)` throws — and `Append` runs inside `[UnmanagedCallersOnly]` callbacks, where an exception crosses native frames and takes the process down instead of failing the request.

## The fix

Past the ceiling, `Append` refuses the bytes and **records** the overflow rather than throwing; `CompleteFinishedRequests` turns that record into a failed request once nghttp2/nghttp3 has unwound. Growth arithmetic moved to `long`.

## What review caught

**1. The ceiling was a default on a type all three protocols share — and it silently truncated h1.**

h1 bounds responses a *different* way: it reads `Content-Length` and rejects an oversize body before allocating, never consulting `Overflowed`. Its `AppendAvailable` also ignores `Append`'s return value. So the default did not protect h1, it broke it — parsing completed while the arena dropped bytes:

```
h1, MaxResponseBytes = 32 MiB, 9 MiB origin
  first version:      200|0          <- empty headers, empty body, no exception
  parent (26a42be):   200|9437184
```

It bit at defaults too: h1 bounds the *body* at 8 MiB while the arena bounded *headers + body*, so a body within header-size of the limit passed h1's check and came back empty.

The arena is now **unbounded unless asked**, and the protocols that need a ceiling ask for one. h1 is untouched and behaves exactly as before.

**2. h2 never applied the ceiling at all.** The option was plumbed through `Http2ClientOptions` -> `ConnectAsync` -> `_maxResponseBytes` and then used only in the exception *text*. The configured value was ignored and the message named a limit it was not enforcing.

**3. A ceiling above `Array.MaxLength` made `Rent` throw** regardless of free memory — inside the very callbacks this PR exists to keep exception-free. `SetMaxArenaBytes` now clamps both ends.

## Tests

Three new, each verified to fail without its fix:

| test | without the fix |
|---|---|
| h1 above the old default ceiling | `expected [200\|9437184], got [200\|0]` |
| h2 enforces `MaxResponseBytes` | `expected the request to fail, got: 200\|1024` |
| h1 past its own limit still fails loudly | guards against the fix simply removing the bound |

Plus the original six unit tests and the h3 end-to-end test (8 KiB cap, 64 KiB response) asserting the caller gets an ordinary exception **and** the reactor still serves afterwards.

`Ioxide.Tests.Http`: 22 passed. `Ioxide.Tests.Unit`: 22 passed.

## Correction to the original description

I claimed writing the e2e test "surfaced a second instance" — `BodyLength` counting bytes that arrived rather than bytes stored. With the `Freeze` guard in place, reverting *only* the counting change is unobservable: `Append` returns short only when `Overflowed`, and `Freeze` then discards the body range anyway. It is belt-and-braces, not an independent bug. The `Freeze` guard is the fix that matters.

## Relationship to #144

h2's `CallbackBeginHeaders` also replaced `pending.Response` rather than keeping it, which crashes the process on any trailered response — a live bug on `main`, fixed separately in #144 so it can land immediately. The same shape is written here so the two rebase cleanly.
