### PR TITLE
fix(httpclient): make the HTTP/1.1 pool disposable and dispose it

### DIFF
--- a/src/clients/ioxide.httpclient/Http1/HttpClientPool.cs
+++ b/src/clients/ioxide.httpclient/Http1/HttpClientPool.cs
@@ -17,7 +17,7 @@ namespace ioxide.httpclient;
 /// Not thread-safe by design: every member runs on the owning reactor thread - requests come from
 /// reactor-thread handlers and every completion resumes there too.
 /// </remarks>
-public sealed class HttpClientPool
+public sealed class HttpClientPool : IDisposable
 {
     private readonly IRingHost _host;
     private readonly HttpClientOptions _options;
@@ -28,6 +28,7 @@ public sealed class HttpClientPool
     private int _live;        // connected + connecting
     private int _opening;
     private long _reopenAtMs; // jittered backoff gate after a failed connect
+    private bool _disposed;
 
     private HttpClientPool(IRingHost host, HttpClientOptions options)
     {
@@ -98,6 +99,12 @@ public sealed class HttpClientPool
 
         while (true)
         {
+            if (_disposed)
+            {
+                throw new HttpClientException(
+                    $"pool for {_options.Host}:{_options.Port} is disposed");
+            }
+
             // Newest first: a recently used connection is the one most likely still warm at the
             // peer, and it keeps the idle set from cycling through every socket.
             while (_idle.Count > 0)
@@ -173,7 +180,9 @@ public sealed class HttpClientPool
 
     private void Release(HttpClientConnection connection)
     {
-        if (connection.IsBroken)
+        // A disposed pool takes nothing back: this is how connections still checked out at Dispose
+        // are closed - whenever their request finishes.
+        if (connection.IsBroken || _disposed)
         {
             Discard(connection);
             return;
@@ -201,6 +210,11 @@ public sealed class HttpClientPool
 
     private void StartOpen()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
         _live++;
         _opening++;
         _ = OpenOneAsync();
@@ -240,6 +254,13 @@ public sealed class HttpClientPool
     // Ticker: replenish toward PoolSize behind a jittered backoff, and drop idle corpses.
     private void Sweep()
     {
+        if (_disposed)
+        {
+            return;   // AddTicker has no removal API, so a disposed pool must no-op: replenishing
+                      // here would reopen the connections Dispose just closed, for the rest of the
+                      // reactor's life.
+        }
+
         for (int i = _idle.Count - 1; i >= 0; i--)
         {
             if (_idle[i].IsBroken)
@@ -257,4 +278,29 @@ public sealed class HttpClientPool
     }
 
     private static int BackoffMs() => 200 + Random.Shared.Next(200);
+
+    /// <summary>
+    /// Close the idle connections and stop replenishing. Connections currently checked out by an
+    /// in-flight request are not touched - the request owns them, and they are dropped by
+    /// <see cref="Release"/> when it finishes, because a disposed pool takes nothing back.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        _disposed = true;
+
+        foreach (HttpClientConnection connection in _idle)
+        {
+            connection.Dispose();
+        }
+        _live -= _idle.Count;
+        _idle.Clear();
+
+        // Queued callers would otherwise sit until their acquire deadline for connections that are
+        // never coming. Null wakes them to re-check, where the disposed guard fails them at once.
+        WakeWaiters();
+    }
 }

--- a/src/clients/ioxide.httpclient/RingHttpClient.cs
+++ b/src/clients/ioxide.httpclient/RingHttpClient.cs
@@ -342,5 +342,6 @@ public sealed class RingHttpClient : IDisposable
         _disposed = true;
         _http3?.Dispose();
         _http2?.Dispose();
+        _http1.Dispose();
     }
 }

--- a/tests/Ioxide.Tests.Http/HttpClientTests.cs
+++ b/tests/Ioxide.Tests.Http/HttpClientTests.cs
@@ -47,6 +47,38 @@ internal static class HttpClientTests
             Assert.True(elapsed < 6_000, $"took {elapsed} ms - the acquire timeout did not bound the retry loop");
         });
 
+        runner.Test("httpclient h1: a disposed pool closes its connections and stays closed", () =>
+        {
+            // The pool's Sweep runs off a reactor ticker, and AddTicker has no removal API. Before
+            // this the pool had no Dispose at all, so its connections were held for the rest of the
+            // reactor's life and the ticker reopened any that died - forever.
+            int origin = TestServer.Start(OriginHandler);
+            int proxy = StartProxy(origin, poolSize: 2);
+
+            (_, string warm) = Client.Get(proxy, "/plain");
+            Assert.Equal("200|hello from origin", warm);
+
+            Client.Get(proxy, "/dispose");
+
+            // Settled state, not the instant after: a connect already in flight cannot be
+            // cancelled, so it lands and is discarded on arrival. The sleep also spans several
+            // ticker intervals (250 ms each), which is where replenishment would show up.
+            Thread.Sleep(1200);
+
+            (_, string later) = Client.Get(proxy, "/poolstats");
+            Assert.Equal("live=0", later);
+
+            // And a request against the disposed pool fails cleanly rather than hanging out the
+            // acquire budget waiting for connections that are never coming.
+            long start = Environment.TickCount64;
+            (_, string refused) = Client.Get(proxy, "/plain");
+            long elapsed = Environment.TickCount64 - start;
+
+            Assert.True(refused.StartsWith("599|"), $"expected a failure, got: {refused}");
+            Assert.True(refused.Contains("disposed"), $"should say why, got: {refused}");
+            Assert.True(elapsed < 2_000, $"took {elapsed} ms - should fail immediately, not on the deadline");
+        });
+
         runner.Test("httpclient h1: keep-alive reuses connections across requests", () =>
         {
             int origin = TestServer.Start(OriginHandler);
@@ -175,6 +207,11 @@ internal static class HttpClientTests
 
                 if (path == "/poolstats")
                 {
+                    Wire.Write(connection, 200, $"live={upstream.ConnectionCount}");
+                }
+                else if (path == "/dispose")
+                {
+                    upstream.Dispose();
                     Wire.Write(connection, 200, $"live={upstream.ConnectionCount}");
                 }
                 else


### PR DESCRIPTION
Closes #136.

## The bug

`RingHttpClient.Dispose` disposed `_http3` and `_http2` — and not `_http1`. It couldn't: `HttpClientPool` was not `IDisposable` and had no disposed flag anywhere in the file.

`Start` registers `Sweep` as a reactor ticker, and `AddTicker` has no removal API, so once started the pool could not be stopped by anyone:

- its `PoolSize` TCP connections to the origin stayed open for the rest of the reactor's life,
- and `Sweep` replenished toward `PoolSize` every 250 ms, so any that died were reopened — forever.

Standalone `HttpClientPool` users had no shutdown story at all.

## The fix

The h2 and h3 pools already establish the pattern — `Http3ClientPool.Sweep` no-ops after `Dispose` precisely because the ticker cannot be unregistered. The h1 pool predates that and never got it.

It now has the same shape:

- a `_disposed` flag checked by `Sweep`, `AcquireAsync` and `StartOpen`;
- a `Dispose` that closes idle connections, stops replenishment, and wakes queued waiters so they fail at once rather than sitting out the full acquire deadline;
- `Release` discards instead of pooling when disposed, which is how connections still checked out at `Dispose` get closed — whenever their request finishes.

Plus the one-liner this was all blocking: `_http1.Dispose()` in `RingHttpClient.Dispose`.

## Tests

An end-to-end test warms the pool, disposes it through a proxy control path, waits out several ticker intervals, and asserts nothing came back — then that a later request fails immediately and names the reason.

Verified it can fail. Reverting `Dispose`'s body gives:

```
FAIL  httpclient h1: a disposed pool closes its connections and stays closed: expected [live=0], got [live=2]
```

`live=2` is the bug exactly: both connections held open forever.

`Ioxide.Tests.Http`: 19 passed, 0 failed, 0 skipped.

## Note

A ticker-removal API on the reactor would let all three pools drop their zombie-ticker guards. That's a core change and not needed here, so it stays out of this PR.