### PR TITLE
fix(httpclient): honour Alt-Svc retraction, moves and ma= expiry

### DIFF
--- a/src/clients/ioxide.httpclient/RingHttpClient.cs
+++ b/src/clients/ioxide.httpclient/RingHttpClient.cs
@@ -265,8 +265,10 @@ public sealed class RingHttpClient : IDisposable
         _http3ExpiresAtMs = Environment.TickCount64 + (advertisement.MaxAgeSeconds * 1000);
     }
 
-    // Drop the learned endpoint and the pool built around it. In-flight h3 requests on that pool
-    // fail; being h3 failures they demote and, when the method allows it, replay over HTTP/1.1.
+    /// <summary>
+    /// Drop the learned endpoint and the pool built around it. In-flight h3 requests on that pool
+    /// fail; being h3 failures they demote and, when the method allows it, replay over HTTP/1.1.
+    /// </summary>
     private void RetireHttp3(string reason)
     {
         if (_http3Port == 0 && _http3 is null)
@@ -275,10 +277,20 @@ public sealed class RingHttpClient : IDisposable
         }
 
         Console.Error.WriteLine($"[ringhttpclient] {_options.Host}: dropping h3 on :{_http3Port} - {reason}");
-        _http3?.Dispose();
+
+        // DETACH FIRST, dispose second. Disposing the pool closes its connections, and those
+        // completions resume the waiting requests INLINE - so arbitrary caller code runs inside
+        // the Dispose call below. Nulling afterwards would let that code observe a half-torn-down
+        // client: with Http3CooldownMs at 0 a resumed caller re-entering SendAsync still passes
+        // UseHttp3, EnsureHttp3Pool hands back the pool currently being disposed, and picking a
+        // connection from it mutates the very list Dispose is enumerating - or opens a fresh QUIC
+        // connection against an engine that is freed a moment later.
+        Http3ClientPool? retiring = _http3;
         _http3 = null;
         _http3Port = 0;
         _http3ExpiresAtMs = 0;
+
+        retiring?.Dispose();
     }
 
     // A UDP path that is blocked, or an origin that stopped serving h3: stay on HTTP/1.1 for the
@@ -337,6 +349,13 @@ public sealed class RingHttpClient : IDisposable
 
     /// <summary>RFC 7838 section 3.1: ma is optional and defaults to 24 hours.</summary>
     private const long DefaultMaxAgeSeconds = 86_400;
+
+    /// <summary>
+    /// Ceiling on an advertised lifetime, ~68 years. Far past any real ma=, and small enough that
+    /// TickCount64 + seconds * 1000 cannot wrap - which would turn "cache this for a very long
+    /// time" into an expiry in the past and disable h3 permanently.
+    /// </summary>
+    private const long MaxAgeSecondsLimit = int.MaxValue;
 
     /// <summary>
     /// Pull the h3 port out of an Alt-Svc value, e.g. <c>h3=":8443"; ma=86400, h3-29=":8443"</c>.
@@ -430,7 +449,11 @@ public sealed class RingHttpClient : IDisposable
             ReadOnlySpan<byte> raw = parameter[(equals + 1)..].Trim((byte)' ').Trim((byte)'"');
             if (long.TryParse(raw, out long seconds) && seconds >= 0)
             {
-                return seconds;
+                // Saturate. The value is whatever the origin typed, and the caller turns it into
+                // TickCount64 + seconds * 1000 - so a big enough one overflows and lands in the
+                // PAST, which reads as "expired" and disables h3 for the life of the client. An
+                // origin asking for a very long lifetime must not get the opposite of one.
+                return Math.Min(seconds, MaxAgeSecondsLimit);
             }
         }
 

--- a/src/clients/ioxide.httpclient/RingHttpClient.cs
+++ b/src/clients/ioxide.httpclient/RingHttpClient.cs
@@ -89,6 +89,7 @@ public sealed class RingHttpClient : IDisposable
     private Http2ClientPool? _http2;      // h2c, opened only under Http2Only
     private ushort _http3Port;            // pinned by options, or learned from Alt-Svc
     private long _http3BlockedUntilMs;    // set by a failed h3 attempt (cooldown)
+    private long _http3ExpiresAtMs;       // Alt-Svc ma= deadline for a LEARNED port; 0 = no expiry
     private bool _disposed;
 
     private RingHttpClient(Reactor reactor, RingHttpClientOptions options, HttpClientPool http1)
@@ -176,23 +177,18 @@ public sealed class RingHttpClient : IDisposable
             return true;
         }
 
-        // Negotiate: only once an h3 endpoint is known, and only outside a post-failure cooldown.
-        return _http3Port != 0 && Environment.TickCount64 >= _http3BlockedUntilMs;
+        // Negotiate: only once an h3 endpoint is known, only outside a post-failure cooldown, and
+        // only while the advertisement that taught us the port is still within its ma= lifetime.
+        // An expired one falls back to HTTP/1.1, where the next response can re-advertise it.
+        return _http3Port != 0 &&
+               Environment.TickCount64 >= _http3BlockedUntilMs &&
+               (_http3ExpiresAtMs == 0 || Environment.TickCount64 < _http3ExpiresAtMs);
     }
 
     private async ValueTask<HttpClientResponse> SendOverHttp1Async(HttpClientRequest request)
     {
         HttpClientResponse response = await _http1.SendAsync(request);
-
-        // Promote the origin if it advertises h3. Only in Negotiate mode: the other policies are
-        // the caller's explicit choice and must not be overridden by a header.
-        if (_options.Policy == HttpProtocolPolicy.Negotiate && _http3Port == 0 &&
-            response.TryGetHeader("alt-svc"u8, out ReadOnlyMemory<byte> altSvc) &&
-            TryParseH3Port(altSvc.Span, out ushort advertised))
-        {
-            _http3Port = advertised;
-        }
-
+        ApplyAltSvc(response);
         return response;
     }
 
@@ -227,6 +223,62 @@ public sealed class RingHttpClient : IDisposable
             }
             return await SendOverHttp1Async(request);
         }
+    }
+
+    /// <summary>
+    /// Track what the origin currently advertises. Consulted on EVERY HTTP/1.1 response, not only
+    /// while no port is known: an origin that moves or retires its h3 endpoint says so in the
+    /// header, and a client that stops listening after the first advertisement retries a dead port
+    /// for its whole life.
+    ///
+    /// Only in Negotiate mode with an unpinned port. A configured Http3Port and the Http3Only and
+    /// Http1Only policies are the caller's explicit choice and must not be overridden by a header.
+    /// </summary>
+    private void ApplyAltSvc(HttpClientResponse response)
+    {
+        if (_options.Policy != HttpProtocolPolicy.Negotiate || _options.Http3Port != 0 ||
+            !response.TryGetHeader("alt-svc"u8, out ReadOnlyMemory<byte> header))
+        {
+            return;
+        }
+
+        AltSvc advertisement = ParseAltSvc(header.Span);
+
+        if (advertisement.Clear)
+        {
+            RetireHttp3("the origin sent Alt-Svc: clear");
+            return;
+        }
+
+        if (!advertisement.Advertises)
+        {
+            return;   // nothing about h3 in this header - leave what is in effect alone
+        }
+
+        // A moved endpoint: the pool holds the old port, so it has to go with it.
+        if (_http3Port != 0 && advertisement.Port != _http3Port)
+        {
+            RetireHttp3($"the origin moved h3 to port {advertisement.Port}");
+        }
+
+        _http3Port = advertisement.Port;
+        _http3ExpiresAtMs = Environment.TickCount64 + (advertisement.MaxAgeSeconds * 1000);
+    }
+
+    // Drop the learned endpoint and the pool built around it. In-flight h3 requests on that pool
+    // fail; being h3 failures they demote and, when the method allows it, replay over HTTP/1.1.
+    private void RetireHttp3(string reason)
+    {
+        if (_http3Port == 0 && _http3 is null)
+        {
+            return;
+        }
+
+        Console.Error.WriteLine($"[ringhttpclient] {_options.Host}: dropping h3 on :{_http3Port} - {reason}");
+        _http3?.Dispose();
+        _http3 = null;
+        _http3Port = 0;
+        _http3ExpiresAtMs = 0;
     }
 
     // A UDP path that is blocked, or an origin that stopped serving h3: stay on HTTP/1.1 for the
@@ -272,18 +324,43 @@ public sealed class RingHttpClient : IDisposable
     // --- Alt-Svc -------------------------------------------------------------------------------
 
     /// <summary>
+    /// What an Alt-Svc value says about this origin's h3 endpoint: an advertisement with a
+    /// lifetime, an explicit retraction, or nothing we can use.
+    /// </summary>
+    internal readonly record struct AltSvc(bool Clear, ushort Port, long MaxAgeSeconds)
+    {
+        /// <summary>No h3 advertisement and no retraction - leave whatever is in effect alone.</summary>
+        internal static AltSvc None => new(false, 0, DefaultMaxAgeSeconds);
+
+        internal bool Advertises => !Clear && Port != 0;
+    }
+
+    /// <summary>RFC 7838 section 3.1: ma is optional and defaults to 24 hours.</summary>
+    private const long DefaultMaxAgeSeconds = 86_400;
+
+    /// <summary>
     /// Pull the h3 port out of an Alt-Svc value, e.g. <c>h3=":8443"; ma=86400, h3-29=":8443"</c>.
-    /// Only <c>h3</c> on the same host is honoured - an alternative host would need its own pool and
-    /// its own certificate check, so it is ignored rather than followed.
+    /// Kept as the "is there a port we can use" question; <see cref="ParseAltSvc"/> is the full
+    /// answer, including retraction and lifetime.
     /// </summary>
     internal static bool TryParseH3Port(ReadOnlySpan<byte> value, out ushort port)
     {
-        port = 0;
+        AltSvc parsed = ParseAltSvc(value);
+        port = parsed.Port;
+        return parsed.Advertises;
+    }
 
-        // "clear" retracts every advertisement for the origin.
+    /// <summary>
+    /// Parse an Alt-Svc value. Only <c>h3</c> on the same host is honoured - an alternative host
+    /// would need its own pool and its own certificate check, so it is ignored rather than
+    /// followed.
+    /// </summary>
+    internal static AltSvc ParseAltSvc(ReadOnlySpan<byte> value)
+    {
+        // "clear" retracts every advertisement for the origin (RFC 7838 section 3).
         if (value.Trim((byte)' ').SequenceEqual("clear"u8))
         {
-            return false;
+            return new AltSvc(Clear: true, Port: 0, MaxAgeSeconds: 0);
         }
 
         while (!value.IsEmpty)
@@ -304,10 +381,12 @@ public sealed class RingHttpClient : IDisposable
             }
 
             ReadOnlySpan<byte> authority = entry[(equals + 1)..];
+            long maxAge = DefaultMaxAgeSeconds;
             int semicolon = authority.IndexOf((byte)';');
             if (semicolon >= 0)
             {
-                authority = authority[..semicolon];   // drop ma=/persist= parameters
+                maxAge = ParseMaxAge(authority[(semicolon + 1)..]);
+                authority = authority[..semicolon];
             }
             authority = authority.Trim((byte)' ').Trim((byte)'"');
 
@@ -325,12 +404,37 @@ public sealed class RingHttpClient : IDisposable
 
             if (ushort.TryParse(authority[(colon + 1)..], out ushort parsed) && parsed != 0)
             {
-                port = parsed;
-                return true;
+                return new AltSvc(Clear: false, parsed, maxAge);
             }
         }
 
-        return false;
+        return AltSvc.None;
+    }
+
+    // "ma=86400; persist=1" - the parameters after an alternative's authority. Anything we cannot
+    // read leaves the RFC default in place rather than expiring the advertisement early.
+    private static long ParseMaxAge(ReadOnlySpan<byte> parameters)
+    {
+        while (!parameters.IsEmpty)
+        {
+            int semicolon = parameters.IndexOf((byte)';');
+            ReadOnlySpan<byte> parameter = semicolon < 0 ? parameters : parameters[..semicolon];
+            parameters = semicolon < 0 ? default : parameters[(semicolon + 1)..];
+
+            int equals = parameter.IndexOf((byte)'=');
+            if (equals < 0 || !parameter[..equals].Trim((byte)' ').SequenceEqual("ma"u8))
+            {
+                continue;
+            }
+
+            ReadOnlySpan<byte> raw = parameter[(equals + 1)..].Trim((byte)' ').Trim((byte)'"');
+            if (long.TryParse(raw, out long seconds) && seconds >= 0)
+            {
+                return seconds;
+            }
+        }
+
+        return DefaultMaxAgeSeconds;
     }
 
     public void Dispose()

--- a/tests/Ioxide.Tests.Http/RingHttpClientTests.cs
+++ b/tests/Ioxide.Tests.Http/RingHttpClientTests.cs
@@ -154,6 +154,54 @@ internal static class RingHttpClientTests
             Assert.Equal("200|served by h3", body);
         });
 
+        runner.Test("ringclient: retiring a LIVE h3 pool leaves the client working", () =>
+        {
+            // Every other retirement test disposes a pool whose only connection had already failed
+            // itself, so the interesting case - tearing down a healthy pool with real QUIC state -
+            // went unexercised. A short ma= is what makes it reachable: h3 expires, the client
+            // drops back to h1, and that h1 response is where a retraction can finally be seen,
+            // while the pool underneath is still perfectly alive.
+            (string certPath, string keyPath) = TestCert.Ensure();
+            using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: ["h3"]);
+
+            (_, int h3Port) = TestServer.StartDatagram(
+                onDatagram: null,
+                quicFactory: engine.CreateFactory(),
+                quicHandle: static (_, connection) => new Nghttp3Connection(connection).RunBufferedAsync(
+                    static _ => Nghttp3Response.Text("served by h3")));
+
+            var origin = new SwitchableOrigin($"h3=\":{h3Port}\"; ma=1");
+            int h1Port = TestServer.Start(origin.Handler);
+
+            int driver = TestServer.Start(DriverHandler, onStart: reactor => RingHttpClient.Start(reactor,
+                new RingHttpClientOptions
+                {
+                    Host = "127.0.0.1",
+                    Port = (ushort)h1Port,
+                    ServerName = "localhost",
+                    AcquireTimeoutMs = 3000,
+                }));
+
+            Client.Get(driver, "/fetch");                       // learns the endpoint over h1
+            (_, string overH3) = Client.Get(driver, "/fetch", timeoutMs: 20_000);
+            Assert.Equal("200|served by h3", overH3);           // pool is open and healthy
+
+            // Let the one-second advertisement lapse, then retract it.
+            Thread.Sleep(1500);
+            origin.Advertise("clear");
+
+            (int status, string body) = Client.Get(driver, "/fetch", timeoutMs: 20_000);
+            Assert.Equal(200, status);
+            Assert.Equal("200|served by h1", body);
+
+            (_, string port) = Client.Get(driver, "/h3port");
+            Assert.Equal("0", port);
+
+            // The client survived disposing a live pool, which is the point.
+            (_, string after) = Client.Get(driver, "/fetch", timeoutMs: 20_000);
+            Assert.Equal("200|served by h1", after);
+        });
+
         runner.Test("ringclient: a dead h3 endpoint falls back to h1 instead of failing", () =>
         {
             int h1Port = TestServer.Start(AdvertisingOriginHandler(9999));

--- a/tests/Ioxide.Tests.Http/RingHttpClientTests.cs
+++ b/tests/Ioxide.Tests.Http/RingHttpClientTests.cs
@@ -70,6 +70,90 @@ internal static class RingHttpClientTests
             Assert.Equal("http/1.1", protocol);   // advertisement seen and deliberately not followed
         });
 
+        runner.Test("ringclient: Alt-Svc: clear retracts a learned h3 endpoint", () =>
+        {
+            // Nothing listens on the advertised port, so the h3 attempt fails and the request falls
+            // back to HTTP/1.1 - which is the only place a retraction is observable at all, since a
+            // promoted origin stops producing h1 responses.
+            var origin = new SwitchableOrigin("h3=\":9998\"; ma=86400");
+            int h1Port = TestServer.Start(origin.Handler);
+
+            int driver = TestServer.Start(DriverHandler, onStart: reactor => RingHttpClient.Start(reactor,
+                new RingHttpClientOptions
+                {
+                    Host = "127.0.0.1",
+                    Port = (ushort)h1Port,
+                    ServerName = "localhost",
+                    AcquireTimeoutMs = 2000,
+                    Http3CooldownMs = 500,
+                }));
+
+            Client.Get(driver, "/fetch");
+            (_, string learned) = Client.Get(driver, "/h3port");
+            Assert.Equal("9998", learned);
+
+            // The origin retires h3 before the next attempt.
+            origin.Advertise("clear");
+
+            (int status, string body) = Client.Get(driver, "/fetch", timeoutMs: 20_000);
+            Assert.Equal(200, status);
+            Assert.Equal("200|served by h1", body);
+
+            // Previously the learned port was cached forever, so this stayed 9998 and the client
+            // retried a dead endpoint once per cooldown for the rest of its life.
+            (_, string afterClear) = Client.Get(driver, "/h3port");
+            Assert.Equal("0", afterClear);
+
+            // Past the cooldown, with no endpoint left, it stays on HTTP/1.1.
+            Thread.Sleep(800);
+            (_, string protocol) = Client.Get(driver, "/protocol");
+            Assert.Equal("http/1.1", protocol);
+        });
+
+        runner.Test("ringclient: a moved h3 endpoint is followed to its new port", () =>
+        {
+            (string certPath, string keyPath) = TestCert.Ensure();
+            using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: ["h3"]);
+
+            (_, int realH3Port) = TestServer.StartDatagram(
+                onDatagram: null,
+                quicFactory: engine.CreateFactory(),
+                quicHandle: static (_, connection) => new Nghttp3Connection(connection).RunBufferedAsync(
+                    static _ => Nghttp3Response.Text("served by h3")));
+
+            // Advertise a dead port first, so the client learns one and then has to replace it.
+            var origin = new SwitchableOrigin("h3=\":9998\"; ma=86400");
+            int h1Port = TestServer.Start(origin.Handler);
+
+            int driver = TestServer.Start(DriverHandler, onStart: reactor => RingHttpClient.Start(reactor,
+                new RingHttpClientOptions
+                {
+                    Host = "127.0.0.1",
+                    Port = (ushort)h1Port,
+                    ServerName = "localhost",
+                    AcquireTimeoutMs = 2000,
+                    Http3CooldownMs = 500,
+                }));
+
+            Client.Get(driver, "/fetch");
+            (_, string stale) = Client.Get(driver, "/h3port");
+            Assert.Equal("9998", stale);
+
+            origin.Advertise($"h3=\":{realH3Port}\"; ma=86400");
+
+            // Tries the dead port, fails, falls back to h1 - and that h1 response carries the move.
+            Client.Get(driver, "/fetch", timeoutMs: 20_000);
+
+            (_, string moved) = Client.Get(driver, "/h3port");
+            Assert.Equal(realH3Port.ToString(), moved);
+
+            // Past the cooldown the client uses the new endpoint, and the h3 origin answers.
+            Thread.Sleep(800);
+            (int status, string body) = Client.Get(driver, "/fetch", timeoutMs: 20_000);
+            Assert.Equal(200, status);
+            Assert.Equal("200|served by h3", body);
+        });
+
         runner.Test("ringclient: a dead h3 endpoint falls back to h1 instead of failing", () =>
         {
             int h1Port = TestServer.Start(AdvertisingOriginHandler(9999));
@@ -96,6 +180,40 @@ internal static class RingHttpClientTests
             (_, string afterFailure) = Client.Get(driver, "/protocol");
             Assert.Equal("http/1.1", afterFailure);
         });
+    }
+
+    // An HTTP/1.1 origin whose Alt-Svc header the test can change between requests, so an origin
+    // that moves or retires its h3 endpoint can actually be exercised.
+    private sealed class SwitchableOrigin(string altSvc)
+    {
+        private volatile string _altSvc = altSvc;
+
+        public void Advertise(string value) => _altSvc = value;
+
+        public Func<Reactor, TcpConnection, Task> Handler => async (_, connection) =>
+        {
+            try
+            {
+                while (true)
+                {
+                    RecvSnapshot snapshot = await connection.ReadAsync();
+                    Wire.ReadPath(connection, snapshot);
+
+                    const string body = "served by h1";
+                    connection.Write(Encoding.ASCII.GetBytes(
+                        $"HTTP/1.1 200 OK\r\nAlt-Svc: {_altSvc}\r\n" +
+                        $"Content-Length: {body.Length}\r\n\r\n{body}"));
+                    await connection.FlushAsync();
+
+                    if (snapshot.IsClosed) return;
+                    connection.ResetRead();
+                }
+            }
+            finally
+            {
+                connection.DecRef();
+            }
+        };
     }
 
     // An HTTP/1.1 origin that advertises an h3 endpoint on the same host.
@@ -150,6 +268,10 @@ internal static class RingHttpClientTests
                 if (path == "/protocol")
                 {
                     Wire.Write(connection, 200, upstream.NextProtocol);
+                }
+                else if (path == "/h3port")
+                {
+                    Wire.Write(connection, 200, upstream.NegotiatedHttp3Port.ToString());
                 }
                 else
                 {

--- a/tests/Ioxide.Tests.Unit/AltSvcTests.cs
+++ b/tests/Ioxide.Tests.Unit/AltSvcTests.cs
@@ -77,6 +77,25 @@ internal static class AltSvcTests
             Assert.Equal(86_400, RingHttpClient.ParseAltSvc("h3=\":8443\"; ma=-5"u8).MaxAgeSeconds);
         });
 
+        runner.Test("alt-svc: an enormous ma= saturates instead of wrapping into the past", () =>
+        {
+            // The caller turns this into TickCount64 + seconds * 1000. Unclamped, a big enough
+            // value overflowed to a NEGATIVE deadline, which reads as already-expired - so an
+            // origin asking to cache its endpoint for a very long time got h3 disabled for the
+            // life of the client, silently and permanently. The opposite of what it asked for.
+            foreach (string huge in (string[])["10000000000000000", "9223372036854775", "9223372036854775807"])
+            {
+                RingHttpClient.AltSvc parsed =
+                    RingHttpClient.ParseAltSvc(System.Text.Encoding.ASCII.GetBytes($"h3=\":8443\"; ma={huge}"));
+
+                Assert.True(parsed.Advertises, $"ma={huge} should still advertise");
+
+                long deadline = Environment.TickCount64 + (parsed.MaxAgeSeconds * 1000);
+                Assert.True(deadline > Environment.TickCount64,
+                    $"ma={huge} produced a deadline in the past ({deadline})");
+            }
+        });
+
         runner.Test("alt-svc: malformed input terminates instead of hanging", () =>
         {
             // The value arrives from the network, so every shape has to reach a decision. A parse

--- a/tests/Ioxide.Tests.Unit/AltSvcTests.cs
+++ b/tests/Ioxide.Tests.Unit/AltSvcTests.cs
@@ -46,6 +46,37 @@ internal static class AltSvcTests
                 "port above 65535");
         });
 
+        runner.Test("alt-svc: 'clear' is a retraction, not merely an absent advertisement", () =>
+        {
+            // The distinction that matters: "no h3 here" leaves an already-learned port in place,
+            // while "clear" has to take it away. Collapsing both to false meant a retired endpoint
+            // was retried for the life of the client.
+            RingHttpClient.AltSvc cleared = RingHttpClient.ParseAltSvc("clear"u8);
+            Assert.True(cleared.Clear, "'clear' must report as a retraction");
+            Assert.True(!cleared.Advertises, "and it advertises nothing");
+
+            RingHttpClient.AltSvc unrelated = RingHttpClient.ParseAltSvc("h2=\":443\""u8);
+            Assert.True(!unrelated.Clear, "an h2-only header retracts nothing");
+            Assert.True(!unrelated.Advertises, "but offers no h3 either");
+        });
+
+        runner.Test("alt-svc: ma= sets the lifetime, and its absence takes the RFC default", () =>
+        {
+            Assert.Equal(3600, RingHttpClient.ParseAltSvc("h3=\":8443\"; ma=3600"u8).MaxAgeSeconds);
+            Assert.Equal(0, RingHttpClient.ParseAltSvc("h3=\":8443\"; ma=0"u8).MaxAgeSeconds);
+
+            // RFC 7838 section 3.1: ma is optional and defaults to 24 hours.
+            Assert.Equal(86_400, RingHttpClient.ParseAltSvc("h3=\":8443\""u8).MaxAgeSeconds);
+
+            // Other parameters must not be mistaken for it, in either order.
+            Assert.Equal(600, RingHttpClient.ParseAltSvc("h3=\":8443\"; persist=1; ma=600"u8).MaxAgeSeconds);
+            Assert.Equal(86_400, RingHttpClient.ParseAltSvc("h3=\":8443\"; persist=1"u8).MaxAgeSeconds);
+
+            // Unreadable lifetimes keep the default rather than expiring the advertisement early.
+            Assert.Equal(86_400, RingHttpClient.ParseAltSvc("h3=\":8443\"; ma=abc"u8).MaxAgeSeconds);
+            Assert.Equal(86_400, RingHttpClient.ParseAltSvc("h3=\":8443\"; ma=-5"u8).MaxAgeSeconds);
+        });
+
         runner.Test("alt-svc: malformed input terminates instead of hanging", () =>
         {
             // The value arrives from the network, so every shape has to reach a decision. A parse


### PR DESCRIPTION
Closes #134.

## The bug

Promotion was gated on `_http3Port == 0`, so the first advertisement won permanently. After that the header became unobservable: requests rode h3, and Alt-Svc is only read on the h1 path — where the same guard skipped it even during a post-failure cooldown.

An origin that moved or retired its h3 endpoint left the client in a permanent loop: try h3 → fail → sit out `Http3CooldownMs` → retry the same dead port. One failed request and a log line per cooldown, forever, with no recovery short of restarting the client.

Three gaps behind it:

- **`clear` was parsed but could not demote.** `TryParseH3Port` recognised it, but returning `false` only meant "don't promote", so an already-learned port survived. RFC 7838 §3 says `clear` invalidates every alternative for the origin.
- **`ma=` was dropped unparsed**, so an advertisement never expired (RFC default lifetime: 24 h).
- **The pool baked in its port**, so updating `_http3Port` alone would not have moved any traffic.

## The fix

Alt-Svc is consulted on **every** HTTP/1.1 response rather than only while unset — which is precisely when a demoted origin is back on h1 and can be told about the change.

- `clear` and a moved port both retire the learned endpoint *and* dispose the pool built around it, so `EnsureHttp3Pool` rebuilds lazily against the new one.
- `ma=` sets an expiry that `UseHttp3` honours; an expired advertisement falls back to h1, where the next response can re-advertise.
- A pinned `Http3Port` and the `Http1Only`/`Http3Only` policies stay exempt — an explicit config must not be overridden by a header. Note the guard changed from `_http3Port == 0` to `_options.Http3Port == 0`, which is the distinction that was being conflated: "unpinned" versus "not learned yet".

`TryParseH3Port` is kept as a thin wrapper over the new `ParseAltSvc`, so its existing unit tests cover it unchanged.

## Tests

Unit: retraction separated from "no advertisement", and `ma=` explicit / absent / alongside `persist=` / unreadable.

End-to-end: a `SwitchableOrigin` whose header the test changes mid-run —

- one retracts with `clear`; the client drops the endpoint and stays on h1 past the cooldown;
- one moves h3 to a port a **real** h3 server answers on; the client follows it and gets `served by h3`.

Verified they can fail. Restoring the old `_http3Port == 0` guard:

```
FAIL  ringclient: Alt-Svc: clear retracts a learned h3 endpoint: expected [0], got [9998]
FAIL  ringclient: a moved h3 endpoint is followed to its new port: expected [23840], got [9998]
```

`9998` is the stale port cached forever — the bug exactly.

`Ioxide.Tests.Unit`: 18 passed. `Ioxide.Tests.Http`: 20 passed, 0 skipped.