### PR TITLE
test: make the suite fail loudly instead of hanging, flaking or vanishing

### DIFF
--- a/tests/Ioxide.Tests.E2E/Core/CoreTests.cs
+++ b/tests/Ioxide.Tests.E2E/Core/CoreTests.cs
@@ -279,8 +279,7 @@ internal static class CoreTests
                     },
                 });
 
-            Thread.Sleep(200);
-            int before = Fds();
+            int before = FdCount.Stable();
 
             for (int i = 0; i < 10; i++)
             {
@@ -299,15 +298,14 @@ internal static class CoreTests
                 Assert.True(closed, $"connection {i} not closed after the faulting handler released it");
             }
 
-            Thread.Sleep(300);
-            int leaked = Fds() - before;
+            int leaked = FdCount.Stable() - before;
             Assert.True(leaked <= 3, $"{leaked} fds leaked across 10 DecRef-then-throw handlers");
         });
 
         runner.Test("core: Stop() tears down cleanly (thread exits, fds released)", () =>
         {
-            Thread.Sleep(200);   // let earlier tests' recycles settle before the fd baseline
-            int before = Fds();
+            // Waits for the count to stop moving, which is what the old fixed sleep approximated.
+            int before = FdCount.Stable();
 
             (int port, Reactor reactor, Thread thread) = TestServer.StartConfigured(Handlers.Raw,
                 new ServerConfig
@@ -330,9 +328,8 @@ internal static class CoreTests
             Assert.True(thread.Join(3000), "reactor thread did not exit after Stop()");
 
             open.Close();
-            Thread.Sleep(200);
 
-            int leaked = Fds() - before;
+            int leaked = FdCount.Stable() - before;
             Assert.True(leaked <= 2, $"teardown leaked {leaked} fds (ring/listener/wake/conn not closed?)");
 
             bool refused = false;
@@ -348,8 +345,6 @@ internal static class CoreTests
             Assert.True(refused, "listener still accepting after Stop()");
         });
     }
-
-    private static int Fds() => Directory.EnumerateFileSystemEntries("/proc/self/fd").Count();
 
     // Accumulates bytes and answers once per complete request ("\r\n\r\n"-terminated), so pipelined
     // and fragmented requests both get exactly one response each.

--- a/tests/Ioxide.Tests.E2E/Core/HardeningTests.cs
+++ b/tests/Ioxide.Tests.E2E/Core/HardeningTests.cs
@@ -69,8 +69,8 @@ internal static class HardeningTests
                     },
                 });
 
-            Thread.Sleep(200);   // let WaitForListen's probe connection recycle before the baseline
-            int before = Fds();
+            // Stable() already waits out WaitForListen's probe connection recycling.
+            int before = FdCount.Stable();
 
             for (int i = 0; i < 10; i++)
             {
@@ -80,8 +80,7 @@ internal static class HardeningTests
                 Thread.Sleep(20);
             }   // dispose closes the client; the server must observe EOF and recycle
 
-            Thread.Sleep(500);
-            int leaked = Fds() - before;
+            int leaked = FdCount.Stable() - before;
             Assert.True(leaked <= 3, $"{leaked} fds leaked by 10 faulted handlers (CLOSE_WAIT sockets)");
         });
 
@@ -140,8 +139,6 @@ internal static class HardeningTests
             }
         }, skip: !TestServer.KernelAtLeast(6, 12));
     }
-
-    private static int Fds() => Directory.EnumerateFileSystemEntries("/proc/self/fd").Count();
 
     /// <summary>
     /// Connect and keep trying until the server answers, up to a deadline. Capacity in these tests

--- a/tests/Ioxide.Tests.Harness/FdCount.cs
+++ b/tests/Ioxide.Tests.Harness/FdCount.cs
@@ -1,0 +1,43 @@
+namespace Ioxide.Tests;
+
+/// <summary>
+/// Descriptor counting for the leak tests.
+///
+/// The count is process-global, and test servers run until the process exits, so every earlier
+/// test's reactor is still live while a baseline is taken. A connection recycling late, or any
+/// unrelated BCL activity, moves the number. Sleeping a fixed 200 ms and hoping it has settled is
+/// what these tests used to do, and it is the likeliest thing in the suite to go red for no reason.
+///
+/// <see cref="Stable"/> waits for the count to stop moving instead, which is the actual condition
+/// those sleeps were standing in for.
+/// </summary>
+public static class FdCount
+{
+    /// <summary>Open descriptors right now, including every other test's.</summary>
+    public static int Now() => Directory.EnumerateFileSystemEntries("/proc/self/fd").Count();
+
+    /// <summary>
+    /// Poll until two consecutive samples agree, then return that count. Falls back to the last
+    /// sample if it never settles, so a busy machine yields a slightly noisy assertion rather than
+    /// a hang.
+    /// </summary>
+    public static int Stable(int settleMs = 100, int timeoutMs = 5_000)
+    {
+        long deadlineMs = Environment.TickCount64 + timeoutMs;
+        int previous = Now();
+
+        while (Environment.TickCount64 < deadlineMs)
+        {
+            Thread.Sleep(settleMs);
+
+            int current = Now();
+            if (current == previous)
+            {
+                return current;
+            }
+            previous = current;
+        }
+
+        return previous;
+    }
+}

--- a/tests/Ioxide.Tests.Harness/FdCount.cs
+++ b/tests/Ioxide.Tests.Harness/FdCount.cs
@@ -38,6 +38,9 @@ public static class FdCount
             previous = current;
         }
 
+        // Never settled. Say so: an fd assertion measured against a moving baseline is worth
+        // knowing about when it fails, and silence here makes that impossible to diagnose.
+        Console.Error.WriteLine($"[fdcount] never settled within {timeoutMs} ms; using {previous}");
         return previous;
     }
 }

--- a/tests/Ioxide.Tests.Harness/Runner.cs
+++ b/tests/Ioxide.Tests.Harness/Runner.cs
@@ -50,7 +50,7 @@ public sealed class Runner
     private static void RunWithWatchdog(string name, Action body, int timeoutMs)
     {
         Exception? failure = null;
-        var finished = new ManualResetEventSlim(false);
+        using var finished = new ManualResetEventSlim(false);
 
         var worker = new Thread(() =>
         {
@@ -81,12 +81,25 @@ public sealed class Runner
 
         if (failure is not null)
         {
-            throw failure;
+            // Capture/Throw, not `throw failure` - the latter resets the stack to this line, which
+            // discards where the test actually broke.
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(failure).Throw();
         }
     }
 
     public int Summary()
     {
+        // A reactor can die after the test that started it has already passed - in a ticker, a
+        // sweep, a later handler - and every assertion still succeeds. Reporting green in that case
+        // is worse than the unhandled-exception crash this harness replaced, so any death nobody
+        // consumed fails the run here.
+        IReadOnlyList<string> unreported = TestServer.DrainUnreportedFailures();
+        foreach (string failure in unreported)
+        {
+            Console.WriteLine($"FAIL  a test reactor died and no test observed it: {failure}");
+            _failed++;
+        }
+
         Console.WriteLine($"\n{_passed} passed, {_failed} failed, {_skipped} skipped");
         return _failed == 0 ? 0 : 1;
     }

--- a/tests/Ioxide.Tests.Harness/Runner.cs
+++ b/tests/Ioxide.Tests.Harness/Runner.cs
@@ -3,11 +3,18 @@ namespace Ioxide.Tests;
 /// <summary>Tiny test runner: PASS / FAIL / SKIP per test, a summary line, and a non-zero exit on failure.</summary>
 public sealed class Runner
 {
+    /// <summary>
+    /// How long any one test may run before it is called hung. Generous, because several tests
+    /// wait out acquire budgets and cooldowns on purpose - this is a backstop against a wedged
+    /// read, not a performance bar.
+    /// </summary>
+    private const int DefaultTimeoutMs = 120_000;
+
     private int _passed;
     private int _failed;
     private int _skipped;
 
-    public void Test(string name, Action body, bool skip = false)
+    public void Test(string name, Action body, bool skip = false, int timeoutMs = DefaultTimeoutMs)
     {
         if (skip)
         {
@@ -18,7 +25,7 @@ public sealed class Runner
 
         try
         {
-            body();
+            RunWithWatchdog(name, body, timeoutMs);
             Console.WriteLine($"PASS  {name}");
             _passed++;
         }
@@ -26,6 +33,55 @@ public sealed class Runner
         {
             Console.WriteLine($"FAIL  {name}: {e.Message}");
             _failed++;
+        }
+    }
+
+    /// <summary>
+    /// Run the body on a worker and give up on it after <paramref name="timeoutMs"/>. Test bodies
+    /// are synchronous, so one that wedges - a read that never completes, an acquire that never
+    /// resolves - would otherwise hang the whole suite behind the CI job timeout and report
+    /// nothing at all. A hung test is now one FAIL and the rest still run.
+    /// </summary>
+    /// <remarks>
+    /// The worker is abandoned rather than aborted, because .NET cannot abort a thread and killing
+    /// a reactor mid-operation would corrupt every later test anyway. It is a background thread, so
+    /// it cannot keep the process alive past the summary.
+    /// </remarks>
+    private static void RunWithWatchdog(string name, Action body, int timeoutMs)
+    {
+        Exception? failure = null;
+        var finished = new ManualResetEventSlim(false);
+
+        var worker = new Thread(() =>
+        {
+            try
+            {
+                body();
+            }
+            catch (Exception e)
+            {
+                failure = e;
+            }
+            finally
+            {
+                finished.Set();
+            }
+        })
+        {
+            IsBackground = true,
+            Name = $"test-{name}",
+        };
+        worker.Start();
+
+        if (!finished.Wait(timeoutMs))
+        {
+            throw new TimeoutException(
+                $"timed out after {timeoutMs} ms (the test is wedged; later tests still ran)");
+        }
+
+        if (failure is not null)
+        {
+            throw failure;
         }
     }
 

--- a/tests/Ioxide.Tests.Harness/TestServer.cs
+++ b/tests/Ioxide.Tests.Harness/TestServer.cs
@@ -308,14 +308,41 @@ public static class TestServer
         catch (Exception e)
         {
             StartupFailures[port] = e;
+
+            // ALWAYS print, even though WaitForListen may also report it. Only failures that happen
+            // before the listener is up are ever consumed there, and Run opens the listener before
+            // InitSharedRingBuffer, OpenWakeFd and OnStart - so a reactor that dies in any of those
+            // loses the race, WaitForListen's probe succeeds against the backlog, and the real
+            // cause is never seen. Worse, a reactor dying AFTER its own test has passed would leave
+            // the suite green, where before this guard existed it was a loud process kill. Catching
+            // the exception must not make it quieter than not catching it.
+            Console.Error.WriteLine($"[test-reactor:{port}] died: {e}");
         }
     };
+
+    /// <summary>
+    /// Reactor deaths that no WaitForListen consumed, cleared as they are read. A reactor can die
+    /// long after its own test passed - in a ticker, a sweep, a later handler - and nothing else in
+    /// the harness would ever notice, so the runner checks this before reporting success.
+    /// </summary>
+    public static IReadOnlyList<string> DrainUnreportedFailures()
+    {
+        var drained = new List<string>();
+        foreach (int port in StartupFailures.Keys)
+        {
+            if (StartupFailures.TryRemove(port, out Exception? failure))
+            {
+                drained.Add($":{port} - {failure.Message}");
+            }
+        }
+        return drained;
+    }
 
     private static void WaitForListen(int port)
     {
         for (int attempt = 0; attempt < 100; attempt++)
         {
-            if (StartupFailures.TryGetValue(port, out Exception? failure))
+            if (StartupFailures.TryRemove(port, out Exception? failure))
             {
                 throw new Exception($"server on :{port} failed to start: {failure.Message}", failure);
             }

--- a/tests/Ioxide.Tests.Harness/TestServer.cs
+++ b/tests/Ioxide.Tests.Harness/TestServer.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
@@ -55,6 +56,32 @@ public static class TestServer
     /// <summary>Reserve a unique port (e.g. for TcpOptions.ExtraPorts).</summary>
     public static int NextPort() => Interlocked.Increment(ref _nextPort);
 
+    /// <summary>
+    /// A port with nothing listening on it, for the tests that need a connect to be refused - dead
+    /// backends, connect-storm budgets, black-holed h3 endpoints.
+    /// </summary>
+    /// <remarks>
+    /// Derived rather than hardcoded. A literal like 5599 or 9099 is a standing bet that no other
+    /// process on the machine listens there, and losing that bet does not fail the test loudly - it
+    /// inverts it, because the connect succeeds and the refusal being asserted never happens.
+    /// Binding port 0 has the kernel pick one that was free a moment ago, and closing it
+    /// immediately leaves it free.
+    /// </remarks>
+    public static int DeadPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+
+    /// <summary>The UDP flavour: nothing bound, so datagrams to it go nowhere.</summary>
+    public static int DeadUdpPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+
     public static int Start(Func<Reactor, TcpConnection, Task> handle, Action<Reactor>? onStart = null)
         => StartConfigured(handle, DefaultConfig(), onStart).Port;
 
@@ -74,7 +101,7 @@ public static class TestServer
             TcpHandle = handle,
         };
 
-        var thread = new Thread(reactor.Run)
+        var thread = new Thread(RunGuarded(reactor, port))
         {
             IsBackground = true,
             Name = $"test-reactor-{port}",
@@ -160,7 +187,7 @@ public static class TestServer
             OnDatagram = onDatagram,
         };
 
-        var thread = new Thread(reactor.Run)
+        var thread = new Thread(RunGuarded(reactor, tcpPort))
         {
             IsBackground = true,
             Name = $"test-reactor-udp-{udpPort}",
@@ -202,7 +229,7 @@ public static class TestServer
             OnStart = onStart,
         };
 
-        var thread = new Thread(reactor.Run)
+        var thread = new Thread(RunGuarded(reactor, tcpPort))
         {
             IsBackground = true,
             Name = $"test-reactor-h3client-{tcpPort}",
@@ -251,7 +278,7 @@ public static class TestServer
             OnStart = onStart,
         };
 
-        var thread = new Thread(reactor.Run)
+        var thread = new Thread(RunGuarded(reactor, tcpPort))
         {
             IsBackground = true,
             Name = $"test-reactor-h3proxy-{tcpPort}",
@@ -262,10 +289,37 @@ public static class TestServer
         return tcpPort;
     }
 
+    // Startup failures recorded by RunGuarded, keyed by the port that failed, so WaitForListen can
+    // report the real reason instead of "never started listening".
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<int, Exception> StartupFailures = new();
+
+    /// <summary>
+    /// Reactor.Run as a thread body, with the exception caught. Without this a bind or listen
+    /// failure is unhandled on a background thread and .NET terminates the process - so a single
+    /// unlucky port produces ZERO test results rather than one FAIL, which is the worst possible
+    /// way to learn about it in CI.
+    /// </summary>
+    private static ThreadStart RunGuarded(Reactor reactor, int port) => () =>
+    {
+        try
+        {
+            reactor.Run();
+        }
+        catch (Exception e)
+        {
+            StartupFailures[port] = e;
+        }
+    };
+
     private static void WaitForListen(int port)
     {
         for (int attempt = 0; attempt < 100; attempt++)
         {
+            if (StartupFailures.TryGetValue(port, out Exception? failure))
+            {
+                throw new Exception($"server on :{port} failed to start: {failure.Message}", failure);
+            }
+
             try
             {
                 using var probe = new TcpClient();

--- a/tests/Ioxide.Tests.Http/HttpClientTests.cs
+++ b/tests/Ioxide.Tests.Http/HttpClientTests.cs
@@ -36,7 +36,7 @@ internal static class HttpClientTests
             // the deadline never arrived: the pool reopened at syscall speed (~94k connects in 6 s
             // on one reactor), the caller never saw an error, and the request hung forever.
             // The call must now fail within the acquire budget, and the handler must see it.
-            int proxy = StartProxy(originPort: 9099, poolSize: 1, acquireTimeoutMs: 1000);
+            int proxy = StartProxy(originPort: TestServer.DeadPort(), poolSize: 1, acquireTimeoutMs: 1000);
 
             long start = Environment.TickCount64;
             (int status, string body) = Client.Get(proxy, "/plain", timeoutMs: 15_000);

--- a/tests/Ioxide.Tests.Http/RingHttpClientTests.cs
+++ b/tests/Ioxide.Tests.Http/RingHttpClientTests.cs
@@ -52,7 +52,7 @@ internal static class RingHttpClientTests
 
         runner.Test("ringclient: Http1Only ignores an Alt-Svc advertisement", () =>
         {
-            int h1Port = TestServer.Start(AdvertisingOriginHandler(9999));
+            int h1Port = TestServer.Start(AdvertisingOriginHandler(TestServer.DeadUdpPort()));
 
             int driver = TestServer.Start(DriverHandler, onStart: reactor => RingHttpClient.Start(reactor,
                 new RingHttpClientOptions
@@ -72,7 +72,10 @@ internal static class RingHttpClientTests
 
         runner.Test("ringclient: a dead h3 endpoint falls back to h1 instead of failing", () =>
         {
-            int h1Port = TestServer.Start(AdvertisingOriginHandler(9999));
+            // A UDP port with nothing bound: derived rather than hardcoded, because a literal that
+            // turns out to be live does not fail this test - it inverts it.
+            int deadUdpPort = TestServer.DeadUdpPort();
+            int h1Port = TestServer.Start(AdvertisingOriginHandler(deadUdpPort));
 
             // Http3Port is pinned at a port nothing listens on, so the h3 attempt cannot succeed.
             int driver = TestServer.Start(DriverHandler, onStart: reactor => RingHttpClient.Start(reactor,
@@ -80,7 +83,7 @@ internal static class RingHttpClientTests
                 {
                     Host = "127.0.0.1",
                     Port = (ushort)h1Port,
-                    Http3Port = 9999,
+                    Http3Port = (ushort)deadUdpPort,
                     ServerName = "localhost",
                     AcquireTimeoutMs = 2000,
                 }));

--- a/tests/Ioxide.Tests.Pg/PgTests.cs
+++ b/tests/Ioxide.Tests.Pg/PgTests.cs
@@ -10,7 +10,7 @@ internal static class PgTests
         // ---- pg pool fails fast on a dead backend (#1) - needs NO live pg ----
         runner.Test("pg: dead backend fails fast, no hang (#1)", () =>
         {
-            PgOptions dead = PgOpts(pg) with { Port = 5599 };
+            PgOptions dead = PgOpts(pg) with { Port = (ushort)TestServer.DeadPort() };
             int port = TestServer.Start(PgHandlers.Pg, r => PgPool.Start(r, dead));
             (int status, _) = Client.Get(port, "/", timeoutMs: 8000);
             Assert.Equal(500, status);   // PgException surfaced quickly, not a hang


### PR DESCRIPTION
Refs #135. Covers three of the four bullets fully and the actionable half of the fourth; see **Left out** below.

## 1. A wedged test hung the whole suite

Test bodies run synchronously, so one that never returns left only the CI job timeout as a backstop — and that reports *nothing at all*. `Runner` now runs each body on a worker with a deadline.

Verified with a deliberately wedged probe:

```
FAIL  WATCHDOG PROBE: a wedged test: timed out after 2000 ms (the test is wedged; later tests still ran)
PASS  WATCHDOG PROBE: the suite keeps going
17 passed, 1 failed
```

The worker is abandoned rather than aborted — .NET cannot abort a thread, and killing a reactor mid-operation would corrupt every later test anyway. It is a background thread, so it cannot outlive the summary.

## 2. A bind failure killed the process

`Reactor.Run` was the thread body directly, so a bind or listen failure was unhandled on a background thread and .NET terminated the process — **zero test results instead of one FAIL**, which is the worst possible way to learn about it in CI. The harness now wraps it, records the failure against the port, and `WaitForListen` reports the real reason rather than "never started listening".

## 3. fd-leak assertions were sleep-synchronized

The count is process-global and every earlier test's reactor is still live, so `Thread.Sleep(200)` was a guess about when other tests' recycles had finished. `CoreTests` already carried a comment admitting the race it was sleeping around.

`FdCount.Stable()` polls until two consecutive samples agree — the condition those sleeps were approximating — and falls back to the last sample so a busy machine gets a noisy assertion rather than a hang.

## 4. Three tests assumed literal ports were dead

TCP 5599 (Pg dead-backend), TCP 9099 (h1 connect budget), UDP 9999 (black-holed h3). Each is a standing bet that nothing else on the machine listens there, and losing the bet doesn't fail the test — it **inverts** it, because the connect succeeds and the refusal being asserted never happens.

`TestServer.DeadPort()` / `DeadUdpPort()` bind port 0 and close it, so the port was free a moment ago and belongs to no one.

## Left out

The issue also asks for port + errno in the core's socket/bind/listen exceptions (`Reactor.Tcp.cs`'s bare `"bind failed"`). That's a core edit, which is out of scope for this pass — so this PR says `Refs` rather than `Closes`, and #135 stays open for that one line.

## Verification

All seven suites green. E2E run three times end to end, zero failures each time.

---

## Corrections after review

**"ZERO test results" overstates the old behaviour.** The pre-PR crash printed every result so far plus the true exception and stack; only the summary was lost. That matters, because review found the first version of this PR printed strictly *less* cause information than the crash did.

**The guard made the worst failure class quieter.** `RunGuarded` caught the reactor's exception, but only `WaitForListen` read it, and only during `Start*`. `Reactor.Run` opens the listener *before* `InitSharedRingBuffer`, `OpenWakeFd` and `OnStart`, so a reactor dying in any of those loses the race — the probe completes against the listen backlog and the cause is reported nowhere. A reactor dying *after* its own test passed left the suite fully green, where before it was a guaranteed-red process kill.

Fixed in this PR: the catch always writes the death to stderr, and `Summary` drains any death no test consumed and fails the run for it. Demonstrated with a probe throwing from `OnStart`:

```
PASS  PROBE: a reactor that dies in OnStart
FAIL  a test reactor died and no test observed it: :23701 - boom in OnStart
41 passed, 1 failed
EXIT=1
```

Also applied: `ExceptionDispatchInfo` for the watchdog rethrow so the original stack survives, the `ManualResetEventSlim` is disposed, and `FdCount`'s 5 s fallback announces itself instead of silently returning a moving baseline.
