### PR TITLE
test: cover the continuation-affinity behaviour that shipped untested

### DIFF
--- a/tests/Ioxide.Tests.E2E/Core/AffinityTests.cs
+++ b/tests/Ioxide.Tests.E2E/Core/AffinityTests.cs
@@ -1,0 +1,177 @@
+using System.Text;
+using ioxide;
+
+namespace Ioxide.Tests;
+
+/// <summary>
+/// Continuation affinity: after any await inside a handler, execution is back on the reactor that
+/// started it.
+///
+/// The mechanism is a <see cref="ReactorSynchronizationContext"/> installed on the reactor thread,
+/// so an await that is NOT one of ioxide's own - Task.Delay, Task.Run, a BCL HttpClient call -
+/// resumes on the reactor instead of a thread-pool thread. That matters beyond tidiness: the
+/// ring's submission queue and every connection's state are single-threaded by construction, and a
+/// handler that came back on a pool thread would be touching both from the wrong one.
+///
+/// This shipped untested. What follows is the acceptance criteria it was specified against.
+/// </summary>
+internal static class AffinityTests
+{
+    public static void Register(Runner runner)
+    {
+        runner.Test("affinity: a reactor thread carries a ReactorSynchronizationContext", () =>
+        {
+            // The install itself, which everything below depends on.
+            int port = TestServer.Start(async (r, conn) =>
+            {
+                try
+                {
+                    await conn.ReadAsync();
+
+                    SynchronizationContext? context = SynchronizationContext.Current;
+                    bool ours = context is ReactorSynchronizationContext c && ReferenceEquals(c.Reactor, r);
+
+                    Wire.Write(conn, 200, ours ? "installed" : $"wrong context: {context?.GetType().Name ?? "none"}");
+                    await conn.FlushAsync();
+                }
+                finally
+                {
+                    conn.DecRef();
+                }
+            });
+
+            (int status, string body) = Client.Get(port, "/");
+            Assert.Equal(200, status);
+            Assert.Equal("installed", body);
+        });
+
+        runner.Test("affinity: Task.Delay resumes on the reactor", () =>
+        {
+            // A timer completion belongs to the BCL, so without the context this continuation
+            // lands on a thread-pool thread.
+            AssertBackOnReactorAfter(static async () => await Task.Delay(1));
+        });
+
+        runner.Test("affinity: Task.Run resumes on the reactor", () =>
+        {
+            // The awaited work genuinely runs on the pool; only the CONTINUATION comes home.
+            AssertBackOnReactorAfter(static async () => await Task.Run(static () => Thread.Sleep(1)));
+        });
+
+        runner.Test("affinity: a BCL HttpClient call resumes on the reactor", () =>
+        {
+            // The case the context was built for: a handler calling something that knows nothing
+            // about ioxide, whose continuation would otherwise migrate off the reactor for good.
+            int origin = TestServer.Start(Handlers.Raw);
+
+            AssertBackOnReactorAfter(async () =>
+            {
+                using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+                await http.GetStringAsync($"http://127.0.0.1:{origin}/");
+            });
+        });
+
+        runner.Test("affinity: nested awaits all come back", () =>
+        {
+            // Affinity has to survive the whole chain, not just the first hop - a handler that
+            // drifted off on the second await would be just as broken.
+            AssertBackOnReactorAfter(static async () =>
+            {
+                await Task.Delay(1);
+                await Task.Run(static () => { });
+                await Task.Yield();
+            });
+        });
+
+        runner.Test("affinity: an async void callback that throws does not kill the reactor", () =>
+        {
+            // An async void continuation raises on whatever thread resumes it. Once that thread is
+            // the reactor, an unguarded throw would unwind Run() and take the whole reactor with
+            // it - the #92 failure class. DrainPostQ wraps each callback for exactly this.
+            int port = TestServer.Start(async (r, conn) =>
+            {
+                try
+                {
+                    RecvSnapshot snapshot = await conn.ReadAsync();
+                    string path = Wire.ReadPath(conn, snapshot);
+
+                    if (path == "/boom")
+                    {
+                        Explode(r);   // async void: throws from a posted continuation
+                        Wire.Write(conn, 200, "queued");
+                    }
+                    else
+                    {
+                        Wire.Write(conn, 200, "alive");
+                    }
+
+                    await conn.FlushAsync();
+                }
+                finally
+                {
+                    conn.DecRef();
+                }
+            });
+
+            (_, string queued) = Client.Get(port, "/boom");
+            Assert.Equal("queued", queued);
+
+            // Give the posted continuation time to run and throw on the reactor thread.
+            Thread.Sleep(200);
+
+            // The reactor is still serving, which is the whole assertion.
+            for (int i = 0; i < 3; i++)
+            {
+                (int status, string body) = Client.Get(port, "/ping");
+                Assert.Equal(200, status);
+                Assert.Equal("alive", body);
+            }
+        });
+    }
+
+    // Runs `work` inside a handler and reports whether execution came back to the reactor thread
+    // afterwards. The comparison is against the reactor's own view (OnReactorThread), not a thread
+    // id the test captured, so it stays true regardless of how the harness starts reactors.
+    private static void AssertBackOnReactorAfter(Func<Task> work)
+    {
+        int port = TestServer.Start(async (r, conn) =>
+        {
+            try
+            {
+                await conn.ReadAsync();
+
+                string verdict;
+                try
+                {
+                    await work();
+                    verdict = r.OnReactorThread
+                        ? "on-reactor"
+                        : $"MIGRATED to thread {Environment.CurrentManagedThreadId}";
+                }
+                catch (Exception e)
+                {
+                    verdict = $"work failed: {e.Message}";
+                }
+
+                Wire.Write(conn, 200, verdict);
+                await conn.FlushAsync();
+            }
+            finally
+            {
+                conn.DecRef();
+            }
+        });
+
+        (int status, string body) = Client.Get(port, "/", timeoutMs: 20_000);
+        Assert.Equal(200, status);
+        Assert.Equal("on-reactor", body);
+    }
+
+    // async void on purpose: this is the shape whose exception has nowhere to go but the thread
+    // that resumes it.
+    private static async void Explode(Reactor reactor)
+    {
+        await Task.Delay(1);   // resumes on the reactor, via the context
+        throw new InvalidOperationException("async void continuation blew up on the reactor thread");
+    }
+}

--- a/tests/Ioxide.Tests.E2E/Core/AffinityTests.cs
+++ b/tests/Ioxide.Tests.E2E/Core/AffinityTests.cs
@@ -116,8 +116,11 @@ internal static class AffinityTests
             (_, string queued) = Client.Get(port, "/boom");
             Assert.Equal("queued", queued);
 
-            // Give the posted continuation time to run and throw on the reactor thread.
-            Thread.Sleep(200);
+            // Wait for proof the continuation actually RAN. Without this the test asserts only that
+            // the reactor is alive, which it would also be if the continuation had been silently
+            // dropped or never resumed - passing for the opposite of the reason intended.
+            Assert.True(SpinWait.SpinUntil(() => Volatile.Read(ref _explodeReached) == 1, 5_000),
+                "the async void continuation never reached its throw");
 
             // The reactor is still serving, which is the whole assertion.
             for (int i = 0; i < 3; i++)
@@ -167,11 +170,16 @@ internal static class AffinityTests
         Assert.Equal("on-reactor", body);
     }
 
+    // Set immediately before the throw, so the test can tell "the guard handled it" from "the
+    // continuation never ran at all" - which look identical from the outside.
+    private static int _explodeReached;
+
     // async void on purpose: this is the shape whose exception has nowhere to go but the thread
     // that resumes it.
     private static async void Explode(Reactor reactor)
     {
         await Task.Delay(1);   // resumes on the reactor, via the context
+        Volatile.Write(ref _explodeReached, 1);
         throw new InvalidOperationException("async void continuation blew up on the reactor thread");
     }
 }

--- a/tests/Ioxide.Tests.E2E/Program.cs
+++ b/tests/Ioxide.Tests.E2E/Program.cs
@@ -12,6 +12,7 @@ internal static class Program
         var runner = new Runner();
 
         CoreTests.Register(runner);
+        AffinityTests.Register(runner);
         HardeningTests.Register(runner);
         UdpTests.Register(runner);
         QuicTests.Register(runner);


### PR DESCRIPTION
Refs #104.

`ReactorSynchronizationContext` landed in PR #108 and **nothing under `tests/` asserted any of its acceptance criteria** — #104 says as much. So the property it exists to guarantee, that an await inside a handler comes back to the reactor that started it, was resting on nobody having noticed it break.

That property is load-bearing, not cosmetic: the ring's submission queue and every connection's state are single-threaded by construction, and the upstream HTTP clients depend on inline resumption outright.

## The tests

Written against the criteria the feature was specified with:

- the context is installed on the reactor thread and bound to the right reactor
- `Task.Delay` resumes on the reactor
- `Task.Run` resumes on the reactor (the work runs on the pool; only the continuation comes home)
- a **BCL `HttpClient`** call resumes on the reactor — the case the context was built for
- a nested chain (`Delay` → `Run` → `Yield`) all comes back, not just the first hop
- an `async void` continuation that throws does not kill the reactor

The last one matters: once continuations resume on the reactor thread, an unguarded `async void` throw unwinds `Run()` and takes the reactor with it — the #92 failure class. `DrainPostQ` wraps each callback precisely for that, and now something checks.

## Verified by mutation

Removing the `SetSynchronizationContext` call from `BindReactorThread` fails five of the six:

```
FAIL  affinity: a reactor thread carries a ReactorSynchronizationContext: expected [installed], got [wrong context: none]
FAIL  affinity: Task.Delay resumes on the reactor:      expected [on-reactor], got [MIGRATED to thread 16]
FAIL  affinity: Task.Run resumes on the reactor:        expected [on-reactor], got [MIGRATED to thread 18]
FAIL  affinity: a BCL HttpClient call resumes on the reactor: expected [on-reactor], got [MIGRATED to thread 28]
FAIL  affinity: nested awaits all come back:            expected [on-reactor], got [MIGRATED to thread 28]
```

`MIGRATED to thread N` is the exact failure the context prevents. (Core was reverted immediately; nothing in `src/` changes in this PR.)

## What this does not cover

The §4 hot-path strip — masking `UseSchedulingContext` so `ReadAsync`/`FlushAsync` resume *inline* rather than through the post queue — is a performance property, not an observable one from a handler: both paths end up on the reactor thread, only the timing differs. It stays guarded by the bench suite rather than by an assertion here.

`Ioxide.Tests.E2E`: 46 passed, 0 failed.

## #104 after this

Its headline deliverable shipped in #108 and its test gap is now closed. What is left is the decomposition benchmark (needs a mode toggle that was never built) and the opt-out decision — both core changes, so #104 stays open for those rather than being closed here.


---

## Corrections after review

**"Fails five of the six" is wrong.** Under that mutation the sixth test never produces a verdict: during its wait the process dies from the unhandled `InvalidOperationException` (exit 134), no summary prints, and the remaining 28 tests never run. The sample output above ends at the fifth FAIL *because the process died there*, not because the sixth passed.

That matters for how the guard fails in practice. Removing `DrainPostQ`'s try/catch — the regression this test exists for — leaves the other five affinity tests **passing** and then obliterates the suite. CI catches it on the exit code, never as a red test. A test cannot report a failure that kills the process running it.

**The async-void test was also vacuous** and has been fixed in this PR: it had no positive signal that the continuation ever ran, so it asserted only that the reactor was alive — equally true if the continuation had been dropped. `Explode` now sets a flag before throwing and the test waits for it. Removing the `Explode` call now fails it.
