### PR TITLE
fix(httpclient): a trailered HTTP/2 response no longer kills the process

### DIFF
--- a/src/clients/ioxide.httpclient/Http2/Http2ClientConnection.cs
+++ b/src/clients/ioxide.httpclient/Http2/Http2ClientConnection.cs
@@ -432,9 +432,16 @@ public sealed class Http2ClientConnection : IDisposable
     private static unsafe void CallbackBeginHeaders(void* user, int streamId)
     {
         Http2ClientConnection connection = FromUser(user);
+
+        // One response per request, created on the FIRST field section and kept. nghttp2 reports
+        // trailers as HCAT_HEADERS, the same category as the real response after a 1xx, so this
+        // callback fires again at the end of a trailered stream. Replacing the response there
+        // would throw away the assembled one while BodyStart/BodyLength still describe its arena,
+        // and CallbackEndStream would then slice those offsets out of the fresh, near-empty one.
+        // Interim (1xx) heads are cleared by ResetForInterim instead, which reuses this object.
         if (connection._pending.TryGetValue(streamId, out PendingRequest? pending))
         {
-            pending.Response = new HttpClientResponse();
+            pending.Response ??= new HttpClientResponse();
         }
     }
 

--- a/tests/Ioxide.Tests.Http/Http2ClientTests.cs
+++ b/tests/Ioxide.Tests.Http/Http2ClientTests.cs
@@ -17,9 +17,17 @@ internal static class Http2ClientTests
     private const string SidecarHost = "127.0.0.1";
     private const ushort SidecarPort = 14464;
 
+    // A second sidecar serving the same shape of object WITH trailers (nginx add_trailer), because
+    // a trailer section is an extra HEADERS frame the plain sidecar never emits.
+    //
+    //   docker run -d --name nginx-trailer --network host \
+    //     -v .../nginx-trailer.conf:/etc/nginx/nginx.conf:ro -v .../trailer_root:/doc_root:ro nginx
+    private const ushort TrailerSidecarPort = 14466;
+
     public static void Register(Runner runner)
     {
         bool noSidecar = !Sidecars.Reachable(SidecarHost, SidecarPort);
+        bool noTrailerSidecar = !Sidecars.Reachable(SidecarHost, TrailerSidecarPort);
 
         runner.Test("httpclient h2: GET over h2c", () =>
         {
@@ -62,6 +70,30 @@ internal static class Http2ClientTests
             (_, string stats) = Client.Get(driver, "/connstats");
             Assert.Equal("conns=1", stats);
         }, skip: noSidecar);
+
+        runner.Test("httpclient h2: a trailered response survives and keeps its body", () =>
+        {
+            // nghttp2 reports TRAILERS as HCAT_HEADERS - the same category as the real response
+            // after a 1xx - so begin_headers fires a SECOND time at the end of a trailered stream.
+            // While that callback replaced the response, the assembled one was discarded with
+            // BodyStart/BodyLength still describing its arena, and end_stream then sliced those
+            // offsets out of the fresh, near-empty one: a large body threw
+            // ArgumentOutOfRangeException from inside [UnmanagedCallersOnly] and killed the
+            // process, a small one came back as silent garbage with status 0.
+            //
+            // The 20 KB object is deliberate. It cannot fit the trailer section's arena, so a
+            // regression here is a dead process rather than a merely wrong-looking string.
+            int driver = TestServer.Start(DriverHandler, onStart: reactor =>
+                Http2ClientPool.Start(reactor, TrailerOptions()));
+
+            (int status, string body) = Client.Get(driver, "/big.html", timeoutMs: 20_000);
+            Assert.Equal(200, status);
+            Assert.Equal("200|20000", body);
+
+            // Still serving afterwards - the half that a crash would take with it.
+            (_, string second) = Client.Get(driver, "/big.html", timeoutMs: 20_000);
+            Assert.Equal("200|20000", second);
+        }, skip: noTrailerSidecar);
     }
 
     // Sends a POST with a 4 KiB body and reports the status, so a dropped body shows up as a
@@ -112,6 +144,8 @@ internal static class Http2ClientTests
         Port = SidecarPort,
         PoolSize = 1,
     };
+
+    private static Http2ClientOptions TrailerOptions() => Options() with { Port = TrailerSidecarPort };
 
     private static async Task DriverHandler(Reactor reactor, TcpConnection connection)
     {


### PR DESCRIPTION
**Live bug on `main`.** Found by the review pass on #137, then verified against a real trailer-sending origin.

## The failure

nghttp2 categorises **trailers** as `HCAT_HEADERS` — the same category the real response arrives under after a 1xx. So `on_begin_headers` fires a *second* time at the end of any trailered stream, and h2's `CallbackBeginHeaders` replaced `pending.Response` outright. The assembled response was discarded while `BodyStart`/`BodyLength` still described its arena, and `CallbackEndStream` sliced those offsets out of the fresh one:

```
Unhandled exception. System.ArgumentOutOfRangeException
   at HttpClientResponse.Freeze()
   at Http2ClientConnection.CallbackEndStream(Void*, Int32)
```

Inside an `[UnmanagedCallersOnly]` callback, so it takes the **process** down rather than failing the request. A body small enough to fit the trailer arena is worse in its own way — it returns as silent garbage with `Status = 0` and the real headers replaced by the trailers.

**Every gRPC-over-h2 response takes this path**; trailers are how gRPC carries its status.

## Where it came from

`f82a274` widened the shim's `begin_headers`/`end_headers` to `HCAT_HEADERS` to fix the 1xx interim case, without accounting for trailers sharing that category. Before that widening, trailers never reached the managed callback.

h3 was never affected: it uses `??=` already, and nghttp3's trailer callbacks aren't wired at all.

## The fix

One response per request, created on the first field section and kept. Interim heads are cleared by `ResetForInterim`, which *reuses* the object rather than replacing it — so the 1xx fix this stemmed from still holds.

## Verified

nginx `add_trailer` genuinely emits the second HEADERS frame:

```
HEADERS   stream=1 len=110  flags=0x04
DATA      stream=1 len=8192
DATA      stream=1 len=8192
DATA      stream=1 len=3616
HEADERS   stream=1 len=36   flags=0x05   ← trailers
```

The regression test uses a 20 KB object deliberately: it cannot fit the trailer section's arena, so a regression is a dead process rather than a merely wrong-looking string. Reverting `??=` to `=` reproduces the crash above — the run dies with **no summary and no FAIL line**, taking the remaining tests with it. That is the honest failure mode; CI catches it on exit code, not on a red test.

`Ioxide.Tests.Http`: 19 passed, 0 failed, 0 skipped.

## Note for reviewers

Kept deliberately separate from #138, which touches the same method to wire up `MaxResponseBytes` but needs more work. This one is a two-line fix for a live crash and should land first; #138 rebases onto it.