### PR TITLE
fix(tls): a corrupt TLS record is a failure, not an incomplete one

### DIFF
--- a/src/protocols/ioxide.tls/TlsSession.cs
+++ b/src/protocols/ioxide.tls/TlsSession.cs
@@ -58,6 +58,35 @@ public sealed unsafe class TlsSession : IDisposable
     /// <summary>Plaintext decrypted during the handshake's final flight, if any.</summary>
     public ReadOnlySpan<byte> DrainPlaintext() => _plain.AsSpan(0, _plainLen);
 
+    /// <summary>
+    /// Classify a non-positive SSL_read. False means stop and wait for more ciphertext; a genuine
+    /// protocol failure throws.
+    /// </summary>
+    /// <remarks>
+    /// The distinction this draws used to be missing: every error except ZERO_RETURN was treated as
+    /// "record incomplete", so a bad MAC or a malformed record was indistinguishable from needing
+    /// more bytes. A corrupted stream then looked like a connection that had simply gone quiet, and
+    /// a caller pumping a pipe would wait on it forever.
+    /// </remarks>
+    private bool ShouldKeepReading(int result)
+    {
+        int err = OpenSsl.SSL_get_error(_ssl, result);
+
+        switch (err)
+        {
+            case OpenSsl.SSL_ERROR_WANT_READ:
+            case OpenSsl.SSL_ERROR_WANT_WRITE:
+                return false;   // normal: the record is not complete yet
+
+            case OpenSsl.SSL_ERROR_ZERO_RETURN:
+                Closed = true;  // clean close_notify
+                return false;
+
+            default:
+                throw new IOException($"TLS decrypt failed (error {err}): {OpenSsl.LastError()}");
+        }
+    }
+
     internal void DrainPending()
     {
         while (true)
@@ -83,12 +112,10 @@ public sealed unsafe class TlsSession : IDisposable
                 continue;
             }
 
-            int err = OpenSsl.SSL_get_error(_ssl, n);
-            if (err == OpenSsl.SSL_ERROR_ZERO_RETURN)
+            if (!ShouldKeepReading(n))
             {
-                Closed = true;   // clean close_notify
+                return;
             }
-            return;              // WANT_READ: record incomplete, wait for more bytes
         }
     }
 

--- a/tests/Ioxide.Tests.Harness/TestServer.cs
+++ b/tests/Ioxide.Tests.Harness/TestServer.cs
@@ -394,6 +394,37 @@ public static class Client
         return ReadResponse(ssl);
     }
 
+    /// <summary>
+    /// Complete a TLS handshake, then write bytes that are not a valid TLS record. The server's
+    /// decrypt must surface that as a FAULT rather than as "the record is incomplete, wait for
+    /// more" - a corrupted stream that looks like a quiet connection leaves the reader hanging on
+    /// one that is never going to recover.
+    /// </summary>
+    public static void SendTlsGarbageAfterHandshake(int port, int timeoutMs = 6000)
+    {
+        using var client = new TcpClient();
+        client.Connect("127.0.0.1", port);
+        client.ReceiveTimeout = timeoutMs;
+
+        using var ssl = new SslStream(client.GetStream(), leaveInnerStreamOpen: false, (_, _, _, _) => true);
+        ssl.AuthenticateAsClient(new SslClientAuthenticationOptions
+        {
+            TargetHost = "localhost",
+            EnabledSslProtocols = SslProtocols.Tls13,
+        });
+
+        // Underneath the SslStream, straight onto the socket: a record header claiming a content
+        // type and version no TLS 1.3 peer will accept, followed by noise.
+        NetworkStream raw = client.GetStream();
+        byte[] bogus = [0x17, 0x03, 0x03, 0x00, 0x10, .. Enumerable.Repeat((byte)0xAB, 16)];
+        raw.Write(bogus);
+        raw.Flush();
+
+        // Let the server read and fault before the socket closes under it, so what it reports is
+        // the bad record rather than the disconnect.
+        Thread.Sleep(500);
+    }
+
     // Several requests over one connection (lock-step), to exercise the handler's keep-alive loop.
     public static List<(int Status, string Body)> GetKeepAlive(int port, string path, int count, int timeoutMs = 6000)
     {

--- a/tests/Ioxide.Tests.Tls/DecryptFaultTests.cs
+++ b/tests/Ioxide.Tests.Tls/DecryptFaultTests.cs
@@ -1,0 +1,107 @@
+using ioxide;
+using ioxide.tls;
+using ioxide.utils;
+
+namespace Ioxide.Tests;
+
+/// <summary>
+/// What <see cref="TlsSession.Decrypt"/> does when the stream is not merely incomplete but wrong.
+///
+/// This is the raw path - the one Kestrel's transport, GenHTTP's engine and every hand-written
+/// handler already use - so the behaviour asserted here is what every existing caller gets, with no
+/// adoption of anything new required.
+/// </summary>
+internal static class DecryptFaultTests
+{
+    public static void Register(Runner runner, bool ktls)
+    {
+        runner.Test("tls: a corrupt record faults the decrypt instead of looking incomplete", () =>
+        {
+            // Every non-ZERO_RETURN result used to be treated as "record incomplete, wait for more
+            // bytes", so SSL_ERROR_SSL - a bad MAC, a malformed record - was indistinguishable from
+            // a connection that had simply gone quiet. A handler would then wait forever on a
+            // stream that was never going to recover, and a pipe pump would never complete.
+            (string certPath, string keyPath) = TestCert.Ensure();
+            var options = new TlsOptions { CertificatePath = certPath, KeyPath = keyPath };
+
+            var reported = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            int port = TestServer.Start(DecryptingHandler(reported), r => TlsService.Start(r, options));
+
+            Client.SendTlsGarbageAfterHandshake(port);
+
+            Assert.True(reported.Task.Wait(TimeSpan.FromSeconds(10)),
+                "the handler should have observed something within 10 s");
+
+            // Assert on WHAT happened. The harness probes the port with a raw TCP connection to
+            // learn the server is listening, and that connection fails the handshake - so "an
+            // exception reached the handler" is true before this test sends anything at all.
+            string outcome = reported.Task.Result;
+            Assert.True(outcome.Contains("TLS decrypt failed"),
+                $"expected the decrypt to fault, got: {outcome}");
+        }, skip: !ktls);
+    }
+
+    // Decrypts whatever arrives and publishes the first outcome that is not "more bytes needed":
+    // either the fault, or a clean end of stream (which for this test is the wrong answer).
+    private static Func<Reactor, TcpConnection, Task> DecryptingHandler(TaskCompletionSource<string> reported)
+        => async (reactor, connection) =>
+        {
+            TlsSession? session = null;
+            try
+            {
+                // Outside the reporting path: the liveness probe's failed handshake is not what
+                // this test is about, and counting it would let the test pass without the garbage.
+                try
+                {
+                    session = await reactor.GetService<TlsService>()!.AcceptAsync(connection);
+                }
+                catch
+                {
+                    return;
+                }
+
+                while (true)
+                {
+                    RecvSnapshot snapshot = await connection.ReadAsync();
+
+                    unsafe
+                    {
+                        while (connection.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                        {
+                            try
+                            {
+                                if (item.HasBuffer)
+                                {
+                                    session.Decrypt(item.Ptr, item.Len);
+                                }
+                            }
+                            finally
+                            {
+                                if (item.HasBuffer)
+                                {
+                                    connection.ReturnBuffer(in item);
+                                }
+                            }
+                        }
+                    }
+
+                    connection.ResetRead();
+
+                    if (session.Closed || snapshot.IsClosed)
+                    {
+                        reported.TrySetResult("clean end of stream");
+                        return;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                reported.TrySetResult(e.Message);
+            }
+            finally
+            {
+                session?.Dispose();
+                connection.DecRef();
+            }
+        };
+}

--- a/tests/Ioxide.Tests.Tls/Program.cs
+++ b/tests/Ioxide.Tests.Tls/Program.cs
@@ -18,6 +18,7 @@ internal static class Program
         Console.WriteLine($"kTLS {(ktls ? "available" : "absent - sudo modprobe tls")}\n");
 
         TlsTests.Register(runner, ktls);
+        DecryptFaultTests.Register(runner, ktls);
 
         return runner.Summary();
     }


### PR DESCRIPTION
Split out of #145 so it can land on its own. This is the piece with the widest reach and no adoption cost.

## The bug

`TlsSession` treated **every** non-`ZERO_RETURN` result from `SSL_read` as "record incomplete, wait for more bytes":

```csharp
if (SSL_get_error(...) == SSL_ERROR_ZERO_RETURN) Closed = true;
return;   // "WANT_READ: record incomplete"
```

So `SSL_ERROR_SSL` — a bad MAC, a malformed record, a protocol violation — was silently swallowed. A corrupted stream became indistinguishable from a connection that had simply gone quiet, and the caller waited on one that was never going to recover.

That is live today for **every** caller of `Decrypt`: the Kestrel transport, GenHTTP's engine, and every hand-written handler. `ShouldKeepReading` now separates the three cases — `WANT_READ`/`WANT_WRITE` mean wait, `ZERO_RETURN` is a clean `close_notify`, anything else throws.

## Why it is split out

The dependency chain in #145 is strictly linear:

```
ShouldKeepReading  ->  DecryptInto  ->  TlsConnectionDualPipe / Kestrel adoption
```

`ShouldKeepReading` depends on nothing, and `DrainPending` — which backs the `Decrypt` everyone already calls — uses it immediately. So this reaches existing callers by upgrading, with nothing to adopt, whereas the rest of #145 is pending the packaging decision in #147 and only de-duplicates GenHTTP. No reason for the fix to wait on that.

## Tested through the raw path

Deliberately not through the new pipe, but through `Decrypt` itself — the path every current caller uses. A handler decrypts what arrives and reports the first outcome that is not "need more bytes"; the client completes a real handshake and then writes a record no TLS 1.3 peer will accept.

Mutation-verified. Restoring the old classification fails it with the symptom itself:

```
FAIL  tls: a corrupt record faults the decrypt instead of looking incomplete:
      expected the decrypt to fault, got: clean end of stream
```

"Clean end of stream" is precisely the bug — a corrupted stream reporting as a polite close.

One trap worth noting, since it caught the first version of this test in #145: the harness probes the port with a raw TCP connection to learn the server is listening, and that connection fails the handshake. "Some exception reached the handler" is therefore true *before* the test sends anything, so handshake faults are excluded from reporting and the assertion checks *what* failed rather than that something did.

## Verification

Needs `sudo modprobe tls` — without it `AcceptAsync` cannot complete the kTLS handoff and the suite skips. With it: Tls 2 passed, E2E 46 passed, Http 35 passed.

## Leaves in #145

`DecryptInto` (one less copy, and Kestrel adopting it), `TlsConnectionDualPipe`, and its pipe tests. #145 will need rebasing onto this.
