### PR TITLE
fix(tls): resume inline on the reactor, and TLS on both hops of every proxy

### DIFF
--- a/Playground/Proxy/H1ToH1/Program.cs
+++ b/Playground/Proxy/H1ToH1/Program.cs
@@ -1,39 +1,54 @@
 using System.Text;
 using ioxide;
 using ioxide.httpclient;
+using ioxide.tls;
 using ioxide.utils;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  proxy h1->h1 - a reverse proxy, whole. Every inbound request is forwarded to an upstream origin
-//  through the ring-native HTTP client and the response is relayed back. BOTH hops - the inbound
-//  connection and the outbound call - run on this reactor's ring and resume inline, so a proxied
-//  request never leaves the thread it arrived on. No thread pool, no cross-core handoff.
+//  proxy h1->h1 - a reverse proxy, whole, with TLS on BOTH hops. Every inbound connection is
+//  terminated here and a fresh TLS connection is opened to the origin; both hops run on this
+//  reactor's ring and resume inline, so a proxied request never leaves the thread it arrived on.
 //
-//      # terminal 1: an origin to forward to
-//      PLAYGROUND_PORT=8081 dotnet run -c Release --project Playground/Tcp/Raw
-//      # terminal 2: the proxy
+//  This is the shape every other sample in this folder varies. Read it first.
+//
+//      # a TLS origin to forward to
+//      PLAYGROUND_PORT=8444 dotnet run -c Release --project Playground/Tls/Ktls
 //      dotnet run -c Release --project Playground/Proxy/H1ToH1
-//      curl http://127.0.0.1:8080/
+//      curl -k https://127.0.0.1:8443/
 //
-//  Needs: ioxide.httpclient
+//  Two different TLS stacks are in play and they are not symmetric. INBOUND is kTLS: the OpenSSL
+//  handshake runs over the ring, then the kernel takes over transmit, so everything this handler
+//  writes is PLAINTEXT and the kernel makes the records. OUTBOUND is userspace: the pool wraps
+//  each upstream connection in its own TlsClientStream. Neither shows up in the proxying code.
+//
+//  Needs the Linux 'tls' module (sudo modprobe tls). Needs: ioxide, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(
+    Env.StrOrNull("PLAYGROUND_TLS_CERT"),
+    Env.StrOrNull("PLAYGROUND_TLS_KEY"));
 
 var config = new ServerConfig
 {
     ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port = Env.Port("PLAYGROUND_PORT", 8443),
     },
 };
 
-var upstream = new HttpClientOptions
-{
-    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
-    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8081),
-    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 8),         // keep-alive connections per reactor
-};
+string upstreamHost = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1");   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8444);
+string upstreamName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost");    // sent as SNI, checked against the cert
+int upstreamPool = Env.Int("PLAYGROUND_UPSTREAM_POOL", 8);                // keep-alive connections per reactor
+
+// The playground's origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = Env.StrOrNull("PLAYGROUND_UPSTREAM_CA") ?? certPath;
+bool upstreamInsecure = Env.Flag("PLAYGROUND_UPSTREAM_INSECURE");
 
 var threads = new Thread[config.ReactorCount];
 
@@ -41,60 +56,89 @@ for (int i = 0; i < threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // Opened on the reactor thread, so the outbound sockets ride this reactor's ring too.
-    reactor.OnStart = r => HttpClientPool.Start(r, upstream);
+    reactor.OnStart = r =>
+    {
+        // Inbound: terminate TLS for clients. ALPN is an ordered list and this proxy speaks one
+        // protocol, so it offers exactly one.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = ["http/1.1"],
+        });
+
+        // Outbound: one context per reactor, shared by that reactor's pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        HttpClientPool.Start(r, new HttpClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = ["http/1.1"],
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =>
     {
         HttpClientPool client = r.GetService<HttpClientPool>();
+        TlsSession? tls = null;
 
         try
         {
+            // The handshake reads and writes through this same connection; after it, the socket
+            // carries kTLS records the kernel en/decrypts.
+            tls = await r.GetService<TlsService>().AcceptAsync(conn);
+
+            // A request can ride in with the handshake's final flight - answer it before parking
+            // in ReadAsync, or the client waits on a response we never send.
+            if (TryReadTarget(tls.DrainPlaintext(), out ReadOnlySpan<byte> early))
+            {
+                await ProxyAsync(conn, client, Encoding.ASCII.GetString(early));
+            }
+
             while (true)
             {
                 RecvSnapshot snapshot = await conn.ReadAsync();
 
-                string path = "/";
-                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                string? path = null;
+                unsafe
                 {
-                    if (item.HasBuffer)
+                    while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
                     {
-                        if (TryReadTarget(item.AsSpan(), out ReadOnlySpan<byte> target))
+                        if (item.HasBuffer)
                         {
-                            path = Encoding.ASCII.GetString(target);
+                            // Records in, plaintext out - the session decrypts what the ring got.
+                            if (TryReadTarget(tls.Decrypt(item.Ptr, item.Len), out ReadOnlySpan<byte> target))
+                            {
+                                path = Encoding.ASCII.GetString(target);
+                            }
+                            conn.ReturnBuffer(in item);
                         }
-                        conn.ReturnBuffer(in item);
                     }
                 }
 
-                try
+                if (path is not null)
                 {
-                    // The outbound call. Same ring, same thread - this await resumes inline.
-                    // The response owns its bytes, so dispose it when you're done with them.
-                    using HttpClientResponse response = await client.GetAsync(path);
-
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $"HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n"));
-                    conn.Write(response.Body.Span);   // bytes straight through, no decode
-                }
-                catch (HttpClientException e)
-                {
-                    // A dead origin surfaces here rather than hanging: the pool bounds the whole
-                    // acquire, so you get an exception and can answer with a 502.
-                    byte[] message = Encoding.ASCII.GetBytes($"upstream: {e.Message}");
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $"HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n"));
-                    conn.Write(message);
+                    await ProxyAsync(conn, client, path);
                 }
 
-                await conn.FlushAsync();
-
-                if (snapshot.IsClosed) return;
+                if (snapshot.IsClosed || tls.Closed) return;
                 conn.ResetRead();
             }
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"[proxy h1->h1] connection failed: {e.Message}");
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -103,14 +147,46 @@ for (int i = 0; i < threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($"[proxy h1->h1] {config.ReactorCount} reactors on :{config.Tcp.Port} "
-                + $"-> {upstream.Host}:{upstream.Port}, {upstream.PoolSize} connections each");
+Console.WriteLine($"[proxy h1->h1] {config.ReactorCount} reactors, https on :{config.Tcp!.Port} "
+                + $"-> https://{upstreamName} ({upstreamHost}:{upstreamPort}), "
+                + $"{upstreamPool} connections each, "
+                + $"verify={(upstreamInsecure ? "OFF" : upstreamCa ?? "system store")}");
 
 foreach (Thread thread in threads)
 {
     thread.Join();
 }
 
+// One request out, one response back. Everything written here is PLAINTEXT: after the handshake
+// kTLS owns transmit, so there is nothing left for us to wrap.
+static async ValueTask ProxyAsync(TcpConnection conn, HttpClientPool client, string path)
+{
+    try
+    {
+        // The outbound call. Same ring, same thread - this await resumes inline. The response
+        // owns its bytes, so dispose it when you're done with them.
+        using HttpClientResponse response = await client.GetAsync(path);
+
+        conn.Write(Encoding.ASCII.GetBytes(
+            $"HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n"));
+        conn.Write(response.Body.Span);   // bytes straight through, no decode
+    }
+    catch (Exception e)
+    {
+        // A dead origin surfaces here rather than hanging: the pool bounds the whole acquire. A
+        // REFUSED CERTIFICATE arrives the same way - the handshake is part of opening the
+        // connection, so a name mismatch reads like any other upstream failure.
+        byte[] message = Encoding.ASCII.GetBytes($"upstream: {e.Message}");
+        conn.Write(Encoding.ASCII.GetBytes(
+            $"HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n"));
+        conn.Write(message);
+    }
+
+    await conn.FlushAsync();
+}
+
+// "GET /sleep?x=1 HTTP/1.1" -> "/sleep". Your framework of choice would do this for you; ioxide
+// deliberately doesn't, so here it is in full.
 static bool TryReadTarget(ReadOnlySpan<byte> request, out ReadOnlySpan<byte> target)
 {
     target = default;

--- a/Playground/Proxy/H1ToH2/Program.cs
+++ b/Playground/Proxy/H1ToH2/Program.cs
@@ -1,41 +1,55 @@
 using System.Text;
 using ioxide;
 using ioxide.httpclient;
+using ioxide.tls;
 using ioxide.utils;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  proxy h1->h2 - a plain HTTP/1.1 server whose upstream calls ride HTTP/2 (h2c). The frontend is
-//  Proxy.H1ToH1's, byte for byte; only the pool changed. That is the point of the matrix: the
-//  protocol on each hop is a pool type, not a rewrite.
+//  proxy h1->h2 - HTTPS in, h2-over-TLS out. Identical to Proxy.H1ToH1 except for the upstream:
+//  the pool type changed, its ALPN offer changed from "http/1.1" to "h2", and PoolSize dropped to
+//  1 because h2 multiplexes - one upstream connection carries every concurrent request.
 //
-//  What the swap buys is fan-in. h1 needs one upstream connection per in-flight request, so the
-//  pool sizes for concurrency; h2 multiplexes, so PoolSize 1 carries every concurrent request on
-//  a single socket. A proxy in front of a few origins can hold one connection to each.
+//  ALPN is what selects h2 here. Offering it is not optional: an origin that hears no ALPN has to
+//  assume a protocol, and assuming h2 is not something any origin does.
 //
-//      # the h2c upstream, moved off 8080 so the proxy can have it
-//      PLAYGROUND_PORT=8081 dotnet run -c Release --project Playground/Http2/Nghttp2
+//      # an h2-over-TLS origin to forward to
+//      PLAYGROUND_PORT=8444 dotnet run -c Release --project Playground/Http2/Tls
 //      dotnet run -c Release --project Playground/Proxy/H1ToH2
-//      curl http://127.0.0.1:8080/anything
+//      curl -k https://127.0.0.1:8443/
 //
-//  Needs: ioxide.httpclient
+//  Two different TLS stacks are in play and they are not symmetric. INBOUND is kTLS: the OpenSSL
+//  handshake runs over the ring, then the kernel takes over transmit, so everything this handler
+//  writes is PLAINTEXT and the kernel makes the records. OUTBOUND is userspace: the pool wraps
+//  each upstream connection in its own TlsClientStream. Neither shows up in the proxying code.
+//
+//  Needs the Linux 'tls' module (sudo modprobe tls). Needs: ioxide, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(
+    Env.StrOrNull("PLAYGROUND_TLS_CERT"),
+    Env.StrOrNull("PLAYGROUND_TLS_KEY"));
 
 var config = new ServerConfig
 {
     ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port = Env.Port("PLAYGROUND_PORT", 8443),
     },
 };
 
-var upstream = new Http2ClientOptions
-{
-    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
-    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8081),
-    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1),         // h2 multiplexes: one connection carries all
-};
+string upstreamHost = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1");   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8444);
+string upstreamName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost");    // sent as SNI, checked against the cert
+int upstreamPool = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1);                // h2 multiplexes: one connection carries all
+
+// The playground's origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = Env.StrOrNull("PLAYGROUND_UPSTREAM_CA") ?? certPath;
+bool upstreamInsecure = Env.Flag("PLAYGROUND_UPSTREAM_INSECURE");
 
 var threads = new Thread[config.ReactorCount];
 
@@ -43,57 +57,89 @@ for (int i = 0; i < threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // Opened on the reactor thread, so the upstream socket rides this reactor's ring too.
-    reactor.OnStart = r => Http2ClientPool.Start(r, upstream);
+    reactor.OnStart = r =>
+    {
+        // Inbound: terminate TLS for clients. ALPN is an ordered list and this proxy speaks one
+        // protocol, so it offers exactly one.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = ["http/1.1"],
+        });
+
+        // Outbound: one context per reactor, shared by that reactor's pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        Http2ClientPool.Start(r, new Http2ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = ["h2"],       // h2 over TLS is chosen by ALPN, never assumed
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =>
     {
         Http2ClientPool client = r.GetService<Http2ClientPool>();
+        TlsSession? tls = null;
 
         try
         {
+            // The handshake reads and writes through this same connection; after it, the socket
+            // carries kTLS records the kernel en/decrypts.
+            tls = await r.GetService<TlsService>().AcceptAsync(conn);
+
+            // A request can ride in with the handshake's final flight - answer it before parking
+            // in ReadAsync, or the client waits on a response we never send.
+            if (TryReadTarget(tls.DrainPlaintext(), out ReadOnlySpan<byte> early))
+            {
+                await ProxyAsync(conn, client, Encoding.ASCII.GetString(early));
+            }
+
             while (true)
             {
                 RecvSnapshot snapshot = await conn.ReadAsync();
 
-                string path = "/";
-                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                string? path = null;
+                unsafe
                 {
-                    if (item.HasBuffer)
+                    while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
                     {
-                        if (TryReadTarget(item.AsSpan(), out ReadOnlySpan<byte> target))
+                        if (item.HasBuffer)
                         {
-                            path = Encoding.ASCII.GetString(target);
+                            // Records in, plaintext out - the session decrypts what the ring got.
+                            if (TryReadTarget(tls.Decrypt(item.Ptr, item.Len), out ReadOnlySpan<byte> target))
+                            {
+                                path = Encoding.ASCII.GetString(target);
+                            }
+                            conn.ReturnBuffer(in item);
                         }
-                        conn.ReturnBuffer(in item);
                     }
                 }
 
-                try
+                if (path is not null)
                 {
-                    // h1 request in, h2 stream out - same ring, same thread, inline resume.
-                    using HttpClientResponse response = await client.GetAsync(path);
-
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $"HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n"));
-                    conn.Write(response.Body.Span);   // bytes straight through, no decode
-                }
-                catch (Exception e)
-                {
-                    byte[] message = Encoding.ASCII.GetBytes($"upstream: {e.Message}");
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $"HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n"));
-                    conn.Write(message);
+                    await ProxyAsync(conn, client, path);
                 }
 
-                await conn.FlushAsync();
-
-                if (snapshot.IsClosed) return;
+                if (snapshot.IsClosed || tls.Closed) return;
                 conn.ResetRead();
             }
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"[proxy h1->h2] connection failed: {e.Message}");
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -102,12 +148,42 @@ for (int i = 0; i < threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($"[proxy h1->h2] {config.ReactorCount} reactors on :{config.Tcp!.Port} "
-                + $"-> h2c {upstream.Host}:{upstream.Port}, {upstream.PoolSize} connection(s) each");
+Console.WriteLine($"[proxy h1->h2] {config.ReactorCount} reactors, https on :{config.Tcp!.Port} "
+                + $"-> h2 https://{upstreamName} ({upstreamHost}:{upstreamPort}), "
+                + $"{upstreamPool} connection(s) each, "
+                + $"verify={(upstreamInsecure ? "OFF" : upstreamCa ?? "system store")}");
 
 foreach (Thread thread in threads)
 {
     thread.Join();
+}
+
+// One request out, one response back. Everything written here is PLAINTEXT: after the handshake
+// kTLS owns transmit, so there is nothing left for us to wrap.
+static async ValueTask ProxyAsync(TcpConnection conn, Http2ClientPool client, string path)
+{
+    try
+    {
+        // The outbound call is an h2 stream on a shared connection, not a socket of its own.
+        // Same ring, same thread - this await resumes inline.
+        using HttpClientResponse response = await client.GetAsync(path);
+
+        conn.Write(Encoding.ASCII.GetBytes(
+            $"HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n"));
+        conn.Write(response.Body.Span);   // bytes straight through, no decode
+    }
+    catch (Exception e)
+    {
+        // A dead origin surfaces here rather than hanging: the pool bounds the whole acquire. A
+        // REFUSED CERTIFICATE arrives the same way - the handshake is part of opening the
+        // connection, so a name mismatch reads like any other upstream failure.
+        byte[] message = Encoding.ASCII.GetBytes($"upstream: {e.Message}");
+        conn.Write(Encoding.ASCII.GetBytes(
+            $"HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n"));
+        conn.Write(message);
+    }
+
+    await conn.FlushAsync();
 }
 
 // "GET /sleep?x=1 HTTP/1.1" -> "/sleep". Your framework of choice would do this for you; ioxide

--- a/Playground/Proxy/H1ToH3/Program.cs
+++ b/Playground/Proxy/H1ToH3/Program.cs
@@ -1,39 +1,49 @@
 using System.Text;
 using ioxide;
 using ioxide.httpclient;
+using ioxide.tls;
 using ioxide.utils;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  proxy h1->h3 - a plain HTTP/1.1 server whose upstream calls ride HTTP/3. Note what the
-//  config does NOT contain: no ServerConfig.Quic, no UDP ports, no certificate. Dialing h3 out
-//  needs none of it - the first connect makes the reactor open a UDP socket on an EPHEMERAL
-//  port (the standalone shape of QUIC client mode), and replies route back by connection ID.
-//  Being an h3 client requires no h3 server.
+//  proxy h1->h3 - HTTPS in over TCP, HTTP/3 out over QUIC. The upstream hop needs no TLS options
+//  at all, because QUIC has no cleartext mode: TLS 1.3 is inside the transport, and the handshake
+//  is the connection handshake. Http3ClientOptions carries ServerName for the same reason the h1
+//  and h2 pools do - it is what the certificate has to match - and nothing else.
 //
-//      dotnet run -c Release --project Playground/Http3/Nghttp3        # the h3 upstream on udp :8443
-//      dotnet run -c Release --project Playground/Proxy/H1ToH3
-//      curl http://127.0.0.1:8080/anything
+//  Note also what the config does NOT contain: no ServerConfig.Quic, no UDP ports, no certificate
+//  for the upstream. Being an HTTP/3 client requires no HTTP/3 server - the first connect opens an
+//  ephemeral UDP socket on this reactor's ring and replies route back by connection ID.
 //
-//  Needs: ioxide.httpclient
+//      dotnet run -c Release --project Playground/Http3/Nghttp3     # h3 origin on udp :8443
+//      PLAYGROUND_UPSTREAM_PORT=8443 dotnet run -c Release --project Playground/Proxy/H1ToH3
+//      curl -k https://127.0.0.1:8443/
+//
+//  Two different TLS stacks are in play and they are not symmetric. INBOUND is kTLS: the OpenSSL
+//  handshake runs over the ring, then the kernel takes over transmit, so everything this handler
+//  writes is PLAINTEXT and the kernel makes the records. OUTBOUND is userspace: the pool wraps
+//  each upstream connection in its own TlsClientStream. Neither shows up in the proxying code.
+//
+//  Needs the Linux 'tls' module (sudo modprobe tls). Needs: ioxide, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(
+    Env.StrOrNull("PLAYGROUND_TLS_CERT"),
+    Env.StrOrNull("PLAYGROUND_TLS_KEY"));
 
 var config = new ServerConfig
 {
     ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port = Env.Port("PLAYGROUND_PORT", 8443),
     },
 };
 
-var upstream = new Http3ClientOptions
-{
-    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
-    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8443),         // the upstream's QUIC (UDP) port
-    ServerName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost"),
-    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1),         // h3 multiplexes: one connection carries all
-};
+string upstreamHost = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1");   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8444);       // the upstream's QUIC (UDP) port
+string upstreamName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost");    // sent as SNI, checked against the cert
+int upstreamPool = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1);                // h3 multiplexes: one connection carries all
 
 var threads = new Thread[config.ReactorCount];
 
@@ -41,58 +51,84 @@ for (int i = 0; i < threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // Opening the pool here is what makes the reactor grow its client-side QUIC transport: an
-    // ephemeral UDP socket, armed on this ring, shared by every upstream connection.
-    reactor.OnStart = r => Http3ClientPool.Start(r, upstream);
+    reactor.OnStart = r =>
+    {
+        // Inbound: terminate TLS for clients. ALPN is an ordered list and this proxy speaks one
+        // protocol, so it offers exactly one.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = ["http/1.1"],
+        });
+
+        // Outbound: no TLS options, because QUIC has no cleartext mode - TLS 1.3 is inside the
+        // transport and ALPN ("h3") is negotiated as part of the connection handshake. Opening
+        // this pool is what makes the reactor grow its client-side QUIC transport.
+        Http3ClientPool.Start(r, new Http3ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            ServerName = upstreamName,
+            PoolSize = upstreamPool,
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =>
     {
         Http3ClientPool client = r.GetService<Http3ClientPool>();
+        TlsSession? tls = null;
 
         try
         {
+            // The handshake reads and writes through this same connection; after it, the socket
+            // carries kTLS records the kernel en/decrypts.
+            tls = await r.GetService<TlsService>().AcceptAsync(conn);
+
+            // A request can ride in with the handshake's final flight - answer it before parking
+            // in ReadAsync, or the client waits on a response we never send.
+            if (TryReadTarget(tls.DrainPlaintext(), out ReadOnlySpan<byte> early))
+            {
+                await ProxyAsync(conn, client, Encoding.ASCII.GetString(early));
+            }
+
             while (true)
             {
                 RecvSnapshot snapshot = await conn.ReadAsync();
 
-                string path = "/";
-                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                string? path = null;
+                unsafe
                 {
-                    if (item.HasBuffer)
+                    while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
                     {
-                        if (TryReadTarget(item.AsSpan(), out ReadOnlySpan<byte> target))
+                        if (item.HasBuffer)
                         {
-                            path = Encoding.ASCII.GetString(target);
+                            // Records in, plaintext out - the session decrypts what the ring got.
+                            if (TryReadTarget(tls.Decrypt(item.Ptr, item.Len), out ReadOnlySpan<byte> target))
+                            {
+                                path = Encoding.ASCII.GetString(target);
+                            }
+                            conn.ReturnBuffer(in item);
                         }
-                        conn.ReturnBuffer(in item);
                     }
                 }
 
-                try
+                if (path is not null)
                 {
-                    // h1 request in, h3 request out - same ring, same thread, inline resume.
-                    using HttpClientResponse response = await client.GetAsync(path);
-
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $"HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n"));
-                    conn.Write(response.Body.Span);   // bytes straight through, no decode
-                }
-                catch (Exception e)
-                {
-                    byte[] message = Encoding.ASCII.GetBytes($"upstream: {e.Message}");
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $"HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n"));
-                    conn.Write(message);
+                    await ProxyAsync(conn, client, path);
                 }
 
-                await conn.FlushAsync();
-
-                if (snapshot.IsClosed) return;
+                if (snapshot.IsClosed || tls.Closed) return;
                 conn.ResetRead();
             }
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"[proxy h1->h3] connection failed: {e.Message}");
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -101,12 +137,41 @@ for (int i = 0; i < threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($"[proxy h1->h3] {config.ReactorCount} reactors on :{config.Tcp!.Port} "
-                + $"-> h3 {upstream.Host}:{upstream.Port} (client-only QUIC, ephemeral port)");
+Console.WriteLine($"[proxy h1->h3] {config.ReactorCount} reactors, https on :{config.Tcp!.Port} "
+                + $"-> h3 {upstreamName} ({upstreamHost}:udp {upstreamPort}), "
+                + $"{upstreamPool} connection(s) each");
 
 foreach (Thread thread in threads)
 {
     thread.Join();
+}
+
+// One request out, one response back. Everything written here is PLAINTEXT: after the handshake
+// kTLS owns transmit, so there is nothing left for us to wrap.
+static async ValueTask ProxyAsync(TcpConnection conn, Http3ClientPool client, string path)
+{
+    try
+    {
+        // The outbound call is a QUIC stream. Both hops are completions on this same ring - one
+        // from a TCP recv, one from a UDP recv - and both resume inline.
+        using HttpClientResponse response = await client.GetAsync(path);
+
+        conn.Write(Encoding.ASCII.GetBytes(
+            $"HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n"));
+        conn.Write(response.Body.Span);   // bytes straight through, no decode
+    }
+    catch (Exception e)
+    {
+        // A dead origin surfaces here rather than hanging: the pool bounds the whole acquire. A
+        // refused certificate arrives the same way - for QUIC the TLS handshake IS the connection
+        // handshake, so it fails as a failed connect.
+        byte[] message = Encoding.ASCII.GetBytes($"upstream: {e.Message}");
+        conn.Write(Encoding.ASCII.GetBytes(
+            $"HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n"));
+        conn.Write(message);
+    }
+
+    await conn.FlushAsync();
 }
 
 // "GET /sleep?x=1 HTTP/1.1" -> "/sleep". Your framework of choice would do this for you; ioxide

--- a/Playground/Proxy/H2ToH1/Program.cs
+++ b/Playground/Proxy/H2ToH1/Program.cs
@@ -2,42 +2,61 @@ using System.Text;
 using ioxide;
 using ioxide.httpclient;
 using ioxide.nghttp2;
+using ioxide.tls;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  proxy h2->h1 - an HTTP/2 front door for an HTTP/1.1 upstream. This is the classic edge shape:
-//  clients get multiplexing and header compression, the origin keeps speaking the protocol it
-//  already speaks.
+//  proxy h2->h1 - an HTTP/2 front door for an HTTP/1.1 origin, TLS on both hops. This is the
+//  classic edge shape: clients get multiplexing and header compression over a real https:// URL,
+//  the origin keeps speaking the protocol it already speaks.
 //
-//  Note the asymmetry it creates. One h2 connection can have a hundred streams in flight, and
-//  each one needs its own h1 upstream connection for the duration - h1 has no multiplexing to
-//  borrow. So the pool sizes for concurrency here, unlike every h2/h3 upstream in this folder.
-//  Run out and the request queues behind a waiter rather than the pool opening unbounded, with
-//  the whole acquire bounded by HttpClientOptions.AcquireTimeoutMs - a saturated origin surfaces
-//  as a 502 on that stream, not as an fd leak.
+//  Browsers will not speak h2 in cleartext, so this is the only way the frontend is reachable
+//  from one. ALPN is what makes it work: the server offers "h2" and the client picks it during
+//  the handshake, before a single byte of HTTP exists.
 //
-//      PLAYGROUND_PORT=8081 dotnet run -c Release --project Playground/Tcp/Raw
+//  Note what Nghttp2Connection is handed - a TlsConnectionDualPipe. It never learns that TLS is
+//  involved: the pipe decrypts on the way in and kTLS encrypts on the way out, so the HTTP/2 code
+//  is byte-for-byte the h2c version.
+//
+//      # a TLS origin to forward to
+//      PLAYGROUND_PORT=8444 dotnet run -c Release --project Playground/Tls/Ktls
 //      dotnet run -c Release --project Playground/Proxy/H2ToH1
-//      curl --http2-prior-knowledge http://127.0.0.1:8080/anything
+//      curl -k --http2 https://127.0.0.1:8443/
 //
-//  Needs: ioxide.nghttp2, ioxide.httpclient
+//  Note the asymmetry this combination creates. One h2 connection can have a hundred streams in
+//  flight, and each one needs its own h1 upstream connection for the duration - h1 has no
+//  multiplexing to borrow. So the pool sizes for concurrency here, unlike every h2/h3 upstream in
+//  this folder. Run out and the request queues behind a waiter rather than the pool opening
+//  unbounded, with the whole acquire bounded by HttpClientOptions.AcquireTimeoutMs - a saturated
+//  origin surfaces as a 502 on that stream, not as an fd leak.
+//
+//  Needs the Linux 'tls' module (sudo modprobe tls). Needs: ioxide, ioxide.nghttp2, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(
+    Env.StrOrNull("PLAYGROUND_TLS_CERT"),
+    Env.StrOrNull("PLAYGROUND_TLS_KEY"));
 
 var config = new ServerConfig
 {
     ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port = Env.Port("PLAYGROUND_PORT", 8443),
     },
 };
 
-var upstream = new HttpClientOptions
-{
-    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
-    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8081),
-    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 32),        // h1 has no multiplexing: size for concurrency
-};
+string upstreamHost = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1");   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8444);
+string upstreamName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost");    // sent as SNI, checked against the cert
+int upstreamPool = Env.Int("PLAYGROUND_UPSTREAM_POOL", 32);               // h1 has no multiplexing: size for concurrency
+
+// The playground's origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = Env.StrOrNull("PLAYGROUND_UPSTREAM_CA") ?? certPath;
+bool upstreamInsecure = Env.Flag("PLAYGROUND_UPSTREAM_INSECURE");
 
 var threads = new Thread[config.ReactorCount];
 
@@ -45,19 +64,51 @@ for (int i = 0; i < threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // The pool's connections belong to THIS reactor's ring - one pool per reactor, no locks.
-    reactor.OnStart = r => HttpClientPool.Start(r, upstream);
+    reactor.OnStart = r =>
+    {
+        // Inbound: terminate TLS and offer only h2, because that is all this frontend serves. A
+        // client that cannot do h2 fails ALPN rather than silently getting something else.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = ["h2"],
+        });
+
+        // Outbound: one context per reactor, shared by that reactor's pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        HttpClientPool.Start(r, new HttpClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = ["http/1.1"],
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =>
     {
         HttpClientPool client = r.GetService<HttpClientPool>();
+        TlsSession? tls = null;
 
         try
         {
+            tls = await r.GetService<TlsService>().AcceptAsync(conn);
+
+            // The decrypt pump lives in the pipe, so everything below is the cleartext sample -
+            // and the pipe resumes inline on this reactor, so the upstream call below does too.
+            await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+
             // Buffered + async: each stream dispatches with its body assembled, and the handler
             // may await - the upstream round trip resumes inline on this reactor. Concurrent
             // streams interleave here, which is exactly why the h1 pool has to be deep.
-            await new Nghttp2Connection(conn).RunBufferedAsync(async request =>
+            await new Nghttp2Connection(pipe).RunBufferedAsync(async request =>
             {
                 try
                 {
@@ -84,7 +135,8 @@ for (int i = 0; i < threads.Length; i++)
                 catch (Exception e)
                 {
                     // Upstream down is a gateway error on this stream, not a dead h2 connection:
-                    // every other stream on it keeps working.
+                    // every other stream on it keeps working. A refused certificate arrives the
+                    // same way - the handshake is part of opening the upstream connection.
                     return new Nghttp2Response
                     {
                         Status = 502,
@@ -93,8 +145,13 @@ for (int i = 0; i < threads.Length; i++)
                 }
             });
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"[proxy h2->h1] connection failed: {e.Message}");
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -103,8 +160,10 @@ for (int i = 0; i < threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($"[proxy h2->h1] {config.ReactorCount} reactors, h2c on :{config.Tcp!.Port} "
-                + $"-> http/1.1 {upstream.Host}:{upstream.Port}, {upstream.PoolSize} connections each");
+Console.WriteLine($"[proxy h2->h1] {config.ReactorCount} reactors, h2 over TLS on :{config.Tcp!.Port} "
+                + $"-> https://{upstreamName} ({upstreamHost}:{upstreamPort}), "
+                + $"{upstreamPool} connections each, "
+                + $"verify={(upstreamInsecure ? "OFF" : upstreamCa ?? "system store")}");
 
 foreach (Thread thread in threads)
 {

--- a/Playground/Proxy/H2ToH2/Program.cs
+++ b/Playground/Proxy/H2ToH2/Program.cs
@@ -2,41 +2,55 @@ using System.Text;
 using ioxide;
 using ioxide.httpclient;
 using ioxide.nghttp2;
+using ioxide.tls;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  proxy h2->h2 - HTTP/2 on both sides. The narrowest proxy in this folder: n client streams on
-//  one inbound connection fan out to n streams on ONE outbound connection, so the whole thing
-//  runs on two sockets per reactor no matter how many requests are in flight.
+//  proxy h2->h2 - HTTP/2 on both sides, TLS on both hops. The narrowest proxy in this folder: n
+//  client streams on one inbound connection fan out to n streams on ONE outbound connection, so
+//  the whole thing runs on two sockets per reactor no matter how many requests are in flight.
+//
+//  ALPN carries h2 in both directions - offered by the server on the way in, offered by the
+//  client on the way out. Neither side ever assumes it.
 //
 //  Two different nghttp2 sessions are involved and they share nothing. The inbound one decodes
 //  HPACK against the client's dynamic table; the outbound one re-encodes against the origin's.
 //  Header state is per-connection in HTTP/2 and cannot be forwarded - a proxy always re-encodes,
-//  which is why "just splice the frames" is not a shortcut that exists.
+//  which is why "just splice the frames" is not a shortcut that exists. TLS makes that doubly
+//  true: the two connections do not even share a key.
 //
-//      # the h2c upstream, moved off 8080 so the proxy can have it
-//      PLAYGROUND_PORT=8081 dotnet run -c Release --project Playground/Http2/Nghttp2
+//      # an h2-over-TLS origin to forward to
+//      PLAYGROUND_PORT=8444 dotnet run -c Release --project Playground/Http2/Tls
 //      dotnet run -c Release --project Playground/Proxy/H2ToH2
-//      curl --http2-prior-knowledge http://127.0.0.1:8080/anything
+//      curl -k --http2 https://127.0.0.1:8443/
 //
-//  Needs: ioxide.nghttp2, ioxide.httpclient
+//  Needs the Linux 'tls' module (sudo modprobe tls). Needs: ioxide, ioxide.nghttp2, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(
+    Env.StrOrNull("PLAYGROUND_TLS_CERT"),
+    Env.StrOrNull("PLAYGROUND_TLS_KEY"));
 
 var config = new ServerConfig
 {
     ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port = Env.Port("PLAYGROUND_PORT", 8443),
     },
 };
 
-var upstream = new Http2ClientOptions
-{
-    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
-    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8081),
-    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1),         // h2 multiplexes: one connection carries all
-};
+string upstreamHost = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1");   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8444);
+string upstreamName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost");    // sent as SNI, checked against the cert
+int upstreamPool = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1);                // h2 multiplexes: one connection carries all
+
+// The playground's origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = Env.StrOrNull("PLAYGROUND_UPSTREAM_CA") ?? certPath;
+bool upstreamInsecure = Env.Flag("PLAYGROUND_UPSTREAM_INSECURE");
 
 var threads = new Thread[config.ReactorCount];
 
@@ -44,15 +58,50 @@ for (int i = 0; i < threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    reactor.OnStart = r => Http2ClientPool.Start(r, upstream);
+    reactor.OnStart = r =>
+    {
+        // Inbound: terminate TLS and offer only h2, because that is all this frontend serves. A
+        // client that cannot do h2 fails ALPN rather than silently getting something else.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = ["h2"],
+        });
+
+        // Outbound: one context per reactor, shared by that reactor's pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        Http2ClientPool.Start(r, new Http2ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = ["h2"],       // h2 over TLS is chosen by ALPN, never assumed
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =>
     {
         Http2ClientPool client = r.GetService<Http2ClientPool>();
+        TlsSession? tls = null;
 
         try
         {
-            await new Nghttp2Connection(conn).RunBufferedAsync(async request =>
+            tls = await r.GetService<TlsService>().AcceptAsync(conn);
+
+            // The decrypt pump lives in the pipe, so everything below is the cleartext sample -
+            // and the pipe resumes inline on this reactor, so the upstream call below does too.
+            await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+
+            // Buffered + async: each stream dispatches with its body assembled, and the handler
+            // may await - the upstream round trip resumes inline on this reactor.
+            await new Nghttp2Connection(pipe).RunBufferedAsync(async request =>
             {
                 try
                 {
@@ -62,7 +111,9 @@ for (int i = 0; i < threads.Length; i++)
                         request.Method, request.Path) { Body = request.Body });
 
                     // Copy before Dispose: the response arena is freed then, and nghttp2 copies
-                    // the h2 response only AFTER this handler returns.
+                    // the h2 response only AFTER this handler returns. A real proxy would also
+                    // drop hop-by-hop headers - Connection, Keep-Alive, Transfer-Encoding are all
+                    // illegal in h2 and would be a protocol error to forward.
                     var proxied = new Nghttp2Response
                     {
                         Status = response.Status,
@@ -76,6 +127,9 @@ for (int i = 0; i < threads.Length; i++)
                 }
                 catch (Exception e)
                 {
+                    // Upstream down is a gateway error on this stream, not a dead h2 connection:
+                    // every other stream on it keeps working. A refused certificate arrives the
+                    // same way - the handshake is part of opening the upstream connection.
                     return new Nghttp2Response
                     {
                         Status = 502,
@@ -84,8 +138,13 @@ for (int i = 0; i < threads.Length; i++)
                 }
             });
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"[proxy h2->h2] connection failed: {e.Message}");
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -94,8 +153,10 @@ for (int i = 0; i < threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($"[proxy h2->h2] {config.ReactorCount} reactors, h2c on :{config.Tcp!.Port} "
-                + $"-> h2c {upstream.Host}:{upstream.Port}");
+Console.WriteLine($"[proxy h2->h2] {config.ReactorCount} reactors, h2 over TLS on :{config.Tcp!.Port} "
+                + $"-> h2 https://{upstreamName} ({upstreamHost}:{upstreamPort}), "
+                + $"{upstreamPool} connection(s) each, "
+                + $"verify={(upstreamInsecure ? "OFF" : upstreamCa ?? "system store")}");
 
 foreach (Thread thread in threads)
 {

--- a/Playground/Proxy/H2ToH3/Program.cs
+++ b/Playground/Proxy/H2ToH3/Program.cs
@@ -2,41 +2,47 @@ using System.Text;
 using ioxide;
 using ioxide.httpclient;
 using ioxide.nghttp2;
+using ioxide.tls;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  proxy h2->h3 - HTTP/2 in over TCP, HTTP/3 out over QUIC. The protocol-translating edge: the
-//  client half of a migration where the origin has moved to h3 and the clients have not.
+//  proxy h2->h3 - HTTP/2 in over TCP, HTTP/3 out over QUIC, encrypted end to end. The
+//  protocol-translating edge: the client half of a migration where the origin moved to h3 and the
+//  clients have not.
 //
-//  Look at what the config does NOT contain: no ServerConfig.Quic, no UDP ports, no certificate.
-//  Dialing h3 out needs none of it - the first connect makes the reactor open a UDP socket on an
-//  EPHEMERAL port, and replies route back by connection ID. Being an h3 client requires no h3
-//  server, exactly as in Proxy.H1ToH3; the frontend changing from h1 to h2 changes nothing about
-//  that half.
+//  Both hops are TLS 1.3 and they get there completely differently. INBOUND is kTLS on a TCP
+//  socket: OpenSSL handshake over the ring, then the kernel owns transmit. OUTBOUND is QUIC,
+//  where TLS is inside the transport and the crypto handshake IS the connection handshake - so
+//  the upstream pool takes no TLS options at all, only the ServerName the certificate must match.
 //
-//      dotnet run -c Release --project Playground/Http3/Nghttp3      # the h3 upstream on udp :8443
-//      dotnet run -c Release --project Playground/Proxy/H2ToH3
-//      curl --http2-prior-knowledge http://127.0.0.1:8080/anything
+//  Note also what the config does NOT contain: no ServerConfig.Quic, no UDP ports. Being an
+//  HTTP/3 client requires no HTTP/3 server - the first connect opens an ephemeral UDP socket on
+//  this reactor's ring and replies route back by connection ID.
 //
-//  Needs: ioxide.nghttp2, ioxide.httpclient
+//      dotnet run -c Release --project Playground/Http3/Nghttp3     # h3 origin on udp :8443
+//      PLAYGROUND_UPSTREAM_PORT=8443 dotnet run -c Release --project Playground/Proxy/H2ToH3
+//      curl -k --http2 https://127.0.0.1:8443/
+//
+//  Needs the Linux 'tls' module (sudo modprobe tls). Needs: ioxide, ioxide.nghttp2, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(
+    Env.StrOrNull("PLAYGROUND_TLS_CERT"),
+    Env.StrOrNull("PLAYGROUND_TLS_KEY"));
 
 var config = new ServerConfig
 {
     ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port = Env.Port("PLAYGROUND_PORT", 8443),
     },
 };
 
-var upstream = new Http3ClientOptions
-{
-    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
-    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8443),         // the upstream's QUIC (UDP) port
-    ServerName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost"),
-    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1),         // h3 multiplexes: one connection carries all
-};
+string upstreamHost = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1");   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8444);       // the upstream's QUIC (UDP) port
+string upstreamName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost");    // sent as SNI, checked against the cert
+int upstreamPool = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1);                // h3 multiplexes: one connection carries all
 
 var threads = new Thread[config.ReactorCount];
 
@@ -44,17 +50,45 @@ for (int i = 0; i < threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // Opening the pool here is what makes the reactor grow its client-side QUIC transport: an
-    // ephemeral UDP socket, armed on this ring, shared by every upstream connection.
-    reactor.OnStart = r => Http3ClientPool.Start(r, upstream);
+    reactor.OnStart = r =>
+    {
+        // Inbound: terminate TLS and offer only h2, because that is all this frontend serves. A
+        // client that cannot do h2 fails ALPN rather than silently getting something else.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = ["h2"],
+        });
+
+        // Outbound: no TLS options, because QUIC has no cleartext mode - TLS 1.3 is inside the
+        // transport and ALPN ("h3") is negotiated as part of the connection handshake. Opening
+        // this pool is what makes the reactor grow its client-side QUIC transport.
+        Http3ClientPool.Start(r, new Http3ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            ServerName = upstreamName,
+            PoolSize = upstreamPool,
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =>
     {
         Http3ClientPool client = r.GetService<Http3ClientPool>();
+        TlsSession? tls = null;
 
         try
         {
-            await new Nghttp2Connection(conn).RunBufferedAsync(async request =>
+            tls = await r.GetService<TlsService>().AcceptAsync(conn);
+
+            // The decrypt pump lives in the pipe, so everything below is the cleartext sample -
+            // and the pipe resumes inline on this reactor, so the upstream call below does too.
+            await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+
+            // Buffered + async: each stream dispatches with its body assembled, and the handler
+            // may await - the upstream round trip resumes inline on this reactor.
+            await new Nghttp2Connection(pipe).RunBufferedAsync(async request =>
             {
                 try
                 {
@@ -64,7 +98,9 @@ for (int i = 0; i < threads.Length; i++)
                         request.Method, request.Path) { Body = request.Body });
 
                     // Copy before Dispose: the response arena is freed then, and nghttp2 copies
-                    // the h2 response only AFTER this handler returns.
+                    // the h2 response only AFTER this handler returns. A real proxy would also
+                    // drop hop-by-hop headers - Connection, Keep-Alive, Transfer-Encoding are all
+                    // illegal in h2 and would be a protocol error to forward.
                     var proxied = new Nghttp2Response
                     {
                         Status = response.Status,
@@ -78,6 +114,9 @@ for (int i = 0; i < threads.Length; i++)
                 }
                 catch (Exception e)
                 {
+                    // Upstream down is a gateway error on this stream, not a dead h2 connection:
+                    // every other stream on it keeps working. A refused certificate arrives the
+                    // same way - the handshake is part of opening the upstream connection.
                     return new Nghttp2Response
                     {
                         Status = 502,
@@ -86,8 +125,13 @@ for (int i = 0; i < threads.Length; i++)
                 }
             });
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"[proxy h2->h3] connection failed: {e.Message}");
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -96,8 +140,9 @@ for (int i = 0; i < threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($"[proxy h2->h3] {config.ReactorCount} reactors, h2c on :{config.Tcp!.Port} "
-                + $"-> h3 {upstream.Host}:{upstream.Port} (client-only QUIC, ephemeral port)");
+Console.WriteLine($"[proxy h2->h3] {config.ReactorCount} reactors, h2 over TLS on :{config.Tcp!.Port} "
+                + $"-> h3 {upstreamName} ({upstreamHost}:udp {upstreamPort}), "
+                + $"{upstreamPool} connection(s) each");
 
 foreach (Thread thread in threads)
 {

--- a/Playground/Proxy/H3ToH1/Program.cs
+++ b/Playground/Proxy/H3ToH1/Program.cs
@@ -36,12 +36,18 @@ var config = new ServerConfig
     },
 };
 
-var upstream = new HttpClientOptions
-{
-    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
-    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8081),
-    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 8),         // keep-alive connections per reactor
-};
+string upstreamHost = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1");   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8444);
+int upstreamPool = Env.Int("PLAYGROUND_UPSTREAM_POOL", 8);                // keep-alive connections per reactor
+
+string upstreamName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost");    // sent as SNI, checked against the cert
+
+// The playground's origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = Env.StrOrNull("PLAYGROUND_UPSTREAM_CA") ?? certPath;
+bool upstreamInsecure = Env.Flag("PLAYGROUND_UPSTREAM_INSECURE");
 
 var threads = new Thread[config.ReactorCount];
 
@@ -49,8 +55,24 @@ for (int i = 0; i < threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // The pool's connections belong to THIS reactor's ring - one pool per reactor, no locks.
-    reactor.OnStart = r => HttpClientPool.Start(r, upstream);
+    reactor.OnStart = r =>
+    {
+        // Outbound: one context per reactor, shared by that reactor's pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        HttpClientPool.Start(r, new HttpClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = ["http/1.1"],
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.QuicHandle = (r, conn) =>
     {
@@ -98,7 +120,8 @@ for (int i = 0; i < threads.Length; i++)
 }
 
 Console.WriteLine($"[proxy h3->h1] {config.ReactorCount} reactors, h3 on udp :{config.Quic!.Port} "
-                + $"-> http/1.1 {upstream.Host}:{upstream.Port}");
+                + $"-> https://{upstreamName} ({upstreamHost}:{upstreamPort}), "
+                + $"verify={(upstreamInsecure ? "OFF" : upstreamCa ?? "system store")}");
 
 foreach (Thread thread in threads)
 {

--- a/Playground/Proxy/H3ToH2/Program.cs
+++ b/Playground/Proxy/H3ToH2/Program.cs
@@ -38,12 +38,18 @@ var config = new ServerConfig
     },
 };
 
-var upstream = new Http2ClientOptions
-{
-    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
-    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8081),
-    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1),         // h2 multiplexes: one connection carries all
-};
+string upstreamHost = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1");   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8444);
+int upstreamPool = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1);                // h2 multiplexes: one connection carries all
+
+string upstreamName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost");    // sent as SNI, checked against the cert
+
+// The playground's origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = Env.StrOrNull("PLAYGROUND_UPSTREAM_CA") ?? certPath;
+bool upstreamInsecure = Env.Flag("PLAYGROUND_UPSTREAM_INSECURE");
 
 var threads = new Thread[config.ReactorCount];
 
@@ -51,7 +57,24 @@ for (int i = 0; i < threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    reactor.OnStart = r => Http2ClientPool.Start(r, upstream);
+    reactor.OnStart = r =>
+    {
+        // Outbound: one context per reactor, shared by that reactor's pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        Http2ClientPool.Start(r, new Http2ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = ["h2"],       // h2 over TLS is chosen by ALPN, never assumed
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.QuicHandle = (r, conn) =>
     {
@@ -95,7 +118,8 @@ for (int i = 0; i < threads.Length; i++)
 }
 
 Console.WriteLine($"[proxy h3->h2] {config.ReactorCount} reactors, h3 on udp :{config.Quic!.Port} "
-                + $"-> h2c {upstream.Host}:{upstream.Port}");
+                + $"-> h2 https://{upstreamName} ({upstreamHost}:{upstreamPort}), "
+                + $"verify={(upstreamInsecure ? "OFF" : upstreamCa ?? "system store")}");
 
 foreach (Thread thread in threads)
 {

--- a/Playground/Proxy/H3ToH3/Program.cs
+++ b/Playground/Proxy/H3ToH3/Program.cs
@@ -12,6 +12,12 @@ using Playground.Shared;
 //  connection - each reactor's outbound rides its own ephemeral-port socket instead, which makes
 //  the reply path deterministic.
 //
+//  This is the one combination that needed no TLS wiring: QUIC has no cleartext mode, so both
+//  hops are TLS 1.3 by construction. There is no TlsService on the way in and no
+//  TlsClientContext on the way out because the crypto handshake IS the connection handshake -
+//  the certificate the QuicEngine serves, and the ServerName the pool verifies, are the whole
+//  configuration. Compare the h1 and h2 frontends, where TLS is a layer you add.
+//
 //      PLAYGROUND_QUIC_PORT=8444 PLAYGROUND_PORT=8090 dotnet run -c Release --project Playground/Http3/Nghttp3
 //      dotnet run -c Release --project Playground/Proxy/H3ToH3
 //      curl --http3-only -ks https://127.0.0.1:8443/anything

--- a/Playground/README.md
+++ b/Playground/README.md
@@ -26,15 +26,15 @@ Run any of them with `dotnet run -c Release --project Playground/<Group>/<Name>`
 | [`Http3.Nghttp3`](Http3/Nghttp3/Program.cs) | 169 | HTTP/3 with **streamed** dispatch, and a `SIGTERM` GOAWAY drain. | `ioxide.ngtcp2`, `ioxide.nghttp3` |
 | [`Http3.Buffered`](Http3/Buffered/Program.cs) | 146 | The same server with **buffered** dispatch - one method call is the whole difference. | `ioxide.ngtcp2`, `ioxide.nghttp3` |
 | [`Quic.Alpn`](Quic/Alpn/Program.cs) | 111 | One QUIC listener, two protocols by ALPN: h3, or raw stream echo over the dual pipe. QUIC-only - `Tcp = null`. | `ioxide.ngtcp2`, `ioxide.nghttp3` |
-| [`Proxy.H1ToH1`](Proxy/H1ToH1/Program.cs) | 131 | A reverse proxy, whole - both hops on one reactor thread. Read this one first. | `ioxide.httpclient` |
-| [`Proxy.H1ToH2`](Proxy/H1ToH2/Program.cs) | 132 | The same frontend, h2 upstream: `PoolSize` 1 carries every concurrent request. | `ioxide.httpclient` |
-| [`Proxy.H1ToH3`](Proxy/H1ToH3/Program.cs) | 131 | h1 in, h3 out - with no `Quic` config at all: the first connect opens an ephemeral client socket. | `ioxide.httpclient` |
-| [`Proxy.H2ToH1`](Proxy/H2ToH1/Program.cs) | 112 | The classic edge: clients get multiplexing, the origin keeps h1. The one combination whose pool must size for concurrency. | `ioxide.nghttp2`, `ioxide.httpclient` |
-| [`Proxy.H2ToH2`](Proxy/H2ToH2/Program.cs) | 103 | h2 both sides - two sockets per reactor whatever the load. Two HPACK tables that cannot be spliced. | `ioxide.nghttp2`, `ioxide.httpclient` |
-| [`Proxy.H2ToH3`](Proxy/H2ToH3/Program.cs) | 105 | The protocol-translating edge: TCP in, QUIC out, no server-side QUIC config. | `ioxide.nghttp2`, `ioxide.httpclient` |
-| [`Proxy.H3ToH1`](Proxy/H3ToH1/Program.cs) | 106 | HTTP/3 front door, HTTP/1.1 upstream - QUIC-only frontend, keep-alive h1 pool behind. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
-| [`Proxy.H3ToH2`](Proxy/H3ToH2/Program.cs) | 103 | The same proxy with the pool swapped: requests multiplex onto one h2c upstream connection. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
-| [`Proxy.H3ToH3`](Proxy/H3ToH3/Program.cs) | 105 | h3 on both sides: the upstream QUIC connections share the serving socket - one fd, both directions. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
+| [`Proxy.H1ToH1`](Proxy/H1ToH1/Program.cs) | 207 | TLS both hops, and the one to read first - kTLS in, `TlsClientContext` out. Everything else here is this with one type changed. | `ioxide.httpclient` |
+| [`Proxy.H1ToH2`](Proxy/H1ToH2/Program.cs) | 208 | The same frontend, h2 upstream chosen by ALPN: `PoolSize` 1 carries every concurrent request. | `ioxide.httpclient` |
+| [`Proxy.H1ToH3`](Proxy/H1ToH3/Program.cs) | 196 | h1 in, h3 out. The upstream takes no TLS options at all - QUIC has no cleartext mode, and no `Quic` config is needed to be a client. | `ioxide.httpclient` |
+| [`Proxy.H2ToH1`](Proxy/H2ToH1/Program.cs) | 171 | The classic edge: h2 over TLS in (browsers refuse h2c), h1 origin behind. The one combination whose pool must size for concurrency. | `ioxide.nghttp2`, `ioxide.httpclient` |
+| [`Proxy.H2ToH2`](Proxy/H2ToH2/Program.cs) | 164 | h2 both sides - two sockets per reactor whatever the load. Two HPACK tables that cannot be spliced, and now two keys. | `ioxide.nghttp2`, `ioxide.httpclient` |
+| [`Proxy.H2ToH3`](Proxy/H2ToH3/Program.cs) | 150 | The protocol-translating edge: kTLS on TCP in, QUIC out, encrypted end to end by two completely different mechanisms. | `ioxide.nghttp2`, `ioxide.httpclient` |
+| [`Proxy.H3ToH1`](Proxy/H3ToH1/Program.cs) | 129 | HTTP/3 front door, TLS h1 upstream. `Tcp = null`, so every TCP socket the process owns is an outbound TLS one. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
+| [`Proxy.H3ToH2`](Proxy/H3ToH2/Program.cs) | 127 | The same proxy with the upstream pool swapped: requests multiplex onto one h2-over-TLS connection. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
+| [`Proxy.H3ToH3`](Proxy/H3ToH3/Program.cs) | 111 | The one that needed no TLS wiring at either end - QUIC has no cleartext mode, so both hops are TLS 1.3 by construction. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
 | [`Clients.Pg`](Clients/Pg/Program.cs) | 181 | A `PgPool` per reactor: scalar queries, prepared params (`/add`, `/upper`), row streaming (`/rows`), errors and timeouts. | `ioxide.pg` |
 | [`Clients.Redis`](Clients/Redis/Program.cs) | 194 | A `RedisPool` per reactor: GET hot path, cache-aside, RESP types, explicit pipelining. | `ioxide.redis` |
 | [`Clients.File`](Clients/File/Program.cs) | 253 | Static files: baked responses, ring reads, disk revalidation, `SIGHUP` reload. | `ioxide.file` |
@@ -130,14 +130,24 @@ answers `500`, which is the error path working.
 | `PLAYGROUND_UPSTREAM_HOST` | `127.0.0.1` |
 | `PLAYGROUND_UPSTREAM_PORT` | `8081` |
 | `PLAYGROUND_UPSTREAM_POOL` | `8` h1 upstream, `32` for `H2ToH1`, `1` for any h2/h3 upstream |
+| `PLAYGROUND_UPSTREAM_SNI` | `localhost` - sent as SNI, and what the origin's certificate must match |
+| `PLAYGROUND_UPSTREAM_CA` | the frontend's own self-signed cert - a private CA goes here |
+| `PLAYGROUND_UPSTREAM_INSECURE` | `1` skips verification: encrypted but **unauthenticated** |
 
 Nine samples, one per frontend x upstream combination: the frontend protocol is the server type
 (`Nghttp2Connection`, `Nghttp3Connection`, or a raw TCP loop) and the upstream protocol is the
 pool type (`HttpClientPool`, `Http2ClientPool`, `Http3ClientPool`). Nothing else differs, which
 is the point.
 
-Each needs an origin to forward to - run one of the servers above on `PLAYGROUND_UPSTREAM_PORT`
-in another terminal. With nothing listening they answer `502` once the acquire timeout elapses.
+**Every hop is TLS.** Facing, that is kTLS for the h1 and h2 frontends (`modprobe tls`) and QUIC's
+own TLS 1.3 for the h3 ones; upstream, a `TlsClientContext` for h1 and h2 and again QUIC for h3.
+The h2 frontends offer only `h2` in ALPN, which is what makes them reachable from a browser at all.
+
+Each needs a **TLS** origin to forward to on `PLAYGROUND_UPSTREAM_PORT` - `Tls.Ktls` for an h1
+upstream, `Http2.Tls` for h2, `Http3.Nghttp3` for h3. They verify its certificate against the same
+self-signed cert they serve, so they work against each other out of the box. With nothing listening
+they answer `502` once the acquire timeout elapses, and a certificate that does not verify arrives
+the same way.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ioxide hands you raw bytes and stays out of HTTP; when you want a framework on t
 `ioxide.Kestrel` swaps the transport under an existing ASP.NET Core app with your endpoints
 unchanged.
 
-> Linux 6.1+ · .NET 10 / .NET 11 · `0.3.149` - experimental
+> Linux 6.1+ · .NET 10 / .NET 11 · `0.4.152` - experimental
 
 **[Documentation](https://mda2av.github.io/ioxide/)** - architecture, guides, and every example as
 runnable code side by side.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1136,6 +1136,11 @@ foreach (Thread t in threads) t.Join();</code></pre>
       protocol is the server you hand the connection to; the upstream protocol is the pool you
       call. Nothing else changes between the nine samples below - not the reactor, not the
       config, not the handler's shape.</p>
+      <p><b>Every hop is TLS</b>, which is the only way an h2 frontend is reachable from a browser
+      at all. It is reached three different ways: <b>kTLS</b> facing (OpenSSL handshake over the
+      ring, then the kernel owns transmit, so the handler writes plaintext), a
+      <code>TlsClientContext</code> upstream for h1 and h2, and for anything h3 <em>nothing</em> -
+      QUIC has no cleartext mode, so TLS 1.3 is already inside the transport.</p>
       <table>
         <tr><th></th><th>upstream h1</th><th>upstream h2</th><th>upstream h3</th></tr>
         <tr><td><b>frontend h1</b><br><span class="mx-t">a raw TCP loop</span></td>
@@ -1165,10 +1170,13 @@ foreach (Thread t in threads) t.Join();</code></pre>
       <b>h2 &rarr; h1</b> is the one sample here that sizes its pool for concurrency.</p>
       <p>Every pane is the corresponding
       <a href="https://github.com/MDA2AV/ioxide/tree/main/Playground/Proxy">Playground/Proxy</a>
-      program, whole, with the sample's environment-variable defaults inlined. None of them filter
-      hop-by-hop headers; a production proxy must, and <code>Connection</code>,
-      <code>Keep-Alive</code> and <code>Transfer-Encoding</code> are protocol errors to forward
-      into h2 or h3 at all.</p>
+      program, whole, with the sample's environment-variable defaults inlined. Two caveats they
+      share. They do not filter hop-by-hop headers - a production proxy must, and
+      <code>Connection</code>, <code>Keep-Alive</code> and <code>Transfer-Encoding</code> are
+      protocol errors to forward into h2 or h3 at all. And they trust the self-signed certificate
+      the playground generates, so they run against each other out of the box; a real deployment
+      points <code>CaFile</code> at a private CA or leaves it null for the system store. Turning
+      <code>VerifyCertificate</code> off leaves the hop encrypted but <em>unauthenticated</em>.</p>
     </div>
   </div>
   <div class="pane pane-pxh1toh1">
@@ -1177,29 +1185,38 @@ foreach (Thread t in threads) t.Join();</code></pre>
       <span class="pane-pkg">ioxide + ioxide.httpclient</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide ioxide.httpclient
-//   PLAYGROUND_PORT=8081 dotnet run --project Playground/Tcp/Raw   # the origin
-//   curl http://127.0.0.1:8080/
+//   PLAYGROUND_PORT=8444 dotnet run --project Playground/Tls/Ktls   # a TLS origin
+//   curl -k https://127.0.0.1:8443/
 
 using System.Text;
 using ioxide;
 using ioxide.httpclient;
+using ioxide.tls;
 using ioxide.utils;
+
+const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
+const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
     ReactorCount = Environment.ProcessorCount,
     Tcp = new TcpOptions
     {
-        Port = 8080,
+        Port = 8443,
     },
 };
 
-var upstream = new HttpClientOptions
-{
-    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
-    Port = 8081,
-    PoolSize = 8,         // keep-alive connections per reactor
-};
+string upstreamHost = &quot;127.0.0.1&quot;;   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = 8444;
+string upstreamName = &quot;localhost&quot;;    // sent as SNI, checked against the cert
+int upstreamPool = 8;                // keep-alive connections per reactor
+
+// The playground&#x27;s origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = certPath;
+bool upstreamInsecure = false;
 
 var threads = new Thread[config.ReactorCount];
 
@@ -1207,60 +1224,89 @@ for (int i = 0; i &lt; threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // Opened on the reactor thread, so the outbound sockets ride this reactor&#x27;s ring too.
-    reactor.OnStart = r =&gt; HttpClientPool.Start(r, upstream);
+    reactor.OnStart = r =&gt;
+    {
+        // Inbound: terminate TLS for clients. ALPN is an ordered list and this proxy speaks one
+        // protocol, so it offers exactly one.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = [&quot;http/1.1&quot;],
+        });
+
+        // Outbound: one context per reactor, shared by that reactor&#x27;s pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        HttpClientPool.Start(r, new HttpClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = [&quot;http/1.1&quot;],
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =&gt;
     {
         HttpClientPool client = r.GetService&lt;HttpClientPool&gt;();
+        TlsSession? tls = null;
 
         try
         {
+            // The handshake reads and writes through this same connection; after it, the socket
+            // carries kTLS records the kernel en/decrypts.
+            tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
+
+            // A request can ride in with the handshake&#x27;s final flight - answer it before parking
+            // in ReadAsync, or the client waits on a response we never send.
+            if (TryReadTarget(tls.DrainPlaintext(), out ReadOnlySpan&lt;byte&gt; early))
+            {
+                await ProxyAsync(conn, client, Encoding.ASCII.GetString(early));
+            }
+
             while (true)
             {
                 RecvSnapshot snapshot = await conn.ReadAsync();
 
-                string path = &quot;/&quot;;
-                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                string? path = null;
+                unsafe
                 {
-                    if (item.HasBuffer)
+                    while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
                     {
-                        if (TryReadTarget(item.AsSpan(), out ReadOnlySpan&lt;byte&gt; target))
+                        if (item.HasBuffer)
                         {
-                            path = Encoding.ASCII.GetString(target);
+                            // Records in, plaintext out - the session decrypts what the ring got.
+                            if (TryReadTarget(tls.Decrypt(item.Ptr, item.Len), out ReadOnlySpan&lt;byte&gt; target))
+                            {
+                                path = Encoding.ASCII.GetString(target);
+                            }
+                            conn.ReturnBuffer(in item);
                         }
-                        conn.ReturnBuffer(in item);
                     }
                 }
 
-                try
+                if (path is not null)
                 {
-                    // The outbound call. Same ring, same thread - this await resumes inline.
-                    // The response owns its bytes, so dispose it when you&#x27;re done with them.
-                    using HttpClientResponse response = await client.GetAsync(path);
-
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $&quot;HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n&quot;));
-                    conn.Write(response.Body.Span);   // bytes straight through, no decode
-                }
-                catch (HttpClientException e)
-                {
-                    // A dead origin surfaces here rather than hanging: the pool bounds the whole
-                    // acquire, so you get an exception and can answer with a 502.
-                    byte[] message = Encoding.ASCII.GetBytes($&quot;upstream: {e.Message}&quot;);
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $&quot;HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n&quot;));
-                    conn.Write(message);
+                    await ProxyAsync(conn, client, path);
                 }
 
-                await conn.FlushAsync();
-
-                if (snapshot.IsClosed) return;
+                if (snapshot.IsClosed || tls.Closed) return;
                 conn.ResetRead();
             }
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($&quot;[proxy h1-&gt;h1] connection failed: {e.Message}&quot;);
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -1269,14 +1315,46 @@ for (int i = 0; i &lt; threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($&quot;[proxy h1-&gt;h1] {config.ReactorCount} reactors on :{config.Tcp.Port} &quot;
-                + $&quot;-&gt; {upstream.Host}:{upstream.Port}, {upstream.PoolSize} connections each&quot;);
+Console.WriteLine($&quot;[proxy h1-&gt;h1] {config.ReactorCount} reactors, https on :{config.Tcp!.Port} &quot;
+                + $&quot;-&gt; https://{upstreamName} ({upstreamHost}:{upstreamPort}), &quot;
+                + $&quot;{upstreamPool} connections each, &quot;
+                + $&quot;verify={(upstreamInsecure ? &quot;OFF&quot; : upstreamCa ?? &quot;system store&quot;)}&quot;);
 
 foreach (Thread thread in threads)
 {
     thread.Join();
 }
 
+// One request out, one response back. Everything written here is PLAINTEXT: after the handshake
+// kTLS owns transmit, so there is nothing left for us to wrap.
+static async ValueTask ProxyAsync(TcpConnection conn, HttpClientPool client, string path)
+{
+    try
+    {
+        // The outbound call. Same ring, same thread - this await resumes inline. The response
+        // owns its bytes, so dispose it when you&#x27;re done with them.
+        using HttpClientResponse response = await client.GetAsync(path);
+
+        conn.Write(Encoding.ASCII.GetBytes(
+            $&quot;HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n&quot;));
+        conn.Write(response.Body.Span);   // bytes straight through, no decode
+    }
+    catch (Exception e)
+    {
+        // A dead origin surfaces here rather than hanging: the pool bounds the whole acquire. A
+        // REFUSED CERTIFICATE arrives the same way - the handshake is part of opening the
+        // connection, so a name mismatch reads like any other upstream failure.
+        byte[] message = Encoding.ASCII.GetBytes($&quot;upstream: {e.Message}&quot;);
+        conn.Write(Encoding.ASCII.GetBytes(
+            $&quot;HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n&quot;));
+        conn.Write(message);
+    }
+
+    await conn.FlushAsync();
+}
+
+// &quot;GET /sleep?x=1 HTTP/1.1&quot; -&gt; &quot;/sleep&quot;. Your framework of choice would do this for you; ioxide
+// deliberately doesn&#x27;t, so here it is in full.
 static bool TryReadTarget(ReadOnlySpan&lt;byte&gt; request, out ReadOnlySpan&lt;byte&gt; target)
 {
     target = default;
@@ -1303,29 +1381,38 @@ static bool TryReadTarget(ReadOnlySpan&lt;byte&gt; request, out ReadOnlySpan&lt;
       <span class="pane-pkg">ioxide + ioxide.httpclient</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide ioxide.httpclient
-//   PLAYGROUND_PORT=8081 dotnet run --project Playground/Http2/Nghttp2
-//   curl http://127.0.0.1:8080/
+//   PLAYGROUND_PORT=8444 dotnet run --project Playground/Http2/Tls  # an h2-over-TLS origin
+//   curl -k https://127.0.0.1:8443/
 
 using System.Text;
 using ioxide;
 using ioxide.httpclient;
+using ioxide.tls;
 using ioxide.utils;
+
+const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
+const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
     ReactorCount = Environment.ProcessorCount,
     Tcp = new TcpOptions
     {
-        Port = 8080,
+        Port = 8443,
     },
 };
 
-var upstream = new Http2ClientOptions
-{
-    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
-    Port = 8081,
-    PoolSize = 1,         // h2 multiplexes: one connection carries all
-};
+string upstreamHost = &quot;127.0.0.1&quot;;   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = 8444;
+string upstreamName = &quot;localhost&quot;;    // sent as SNI, checked against the cert
+int upstreamPool = 1;                // h2 multiplexes: one connection carries all
+
+// The playground&#x27;s origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = certPath;
+bool upstreamInsecure = false;
 
 var threads = new Thread[config.ReactorCount];
 
@@ -1333,57 +1420,89 @@ for (int i = 0; i &lt; threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // Opened on the reactor thread, so the upstream socket rides this reactor&#x27;s ring too.
-    reactor.OnStart = r =&gt; Http2ClientPool.Start(r, upstream);
+    reactor.OnStart = r =&gt;
+    {
+        // Inbound: terminate TLS for clients. ALPN is an ordered list and this proxy speaks one
+        // protocol, so it offers exactly one.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = [&quot;http/1.1&quot;],
+        });
+
+        // Outbound: one context per reactor, shared by that reactor&#x27;s pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        Http2ClientPool.Start(r, new Http2ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = [&quot;h2&quot;],       // h2 over TLS is chosen by ALPN, never assumed
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =&gt;
     {
         Http2ClientPool client = r.GetService&lt;Http2ClientPool&gt;();
+        TlsSession? tls = null;
 
         try
         {
+            // The handshake reads and writes through this same connection; after it, the socket
+            // carries kTLS records the kernel en/decrypts.
+            tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
+
+            // A request can ride in with the handshake&#x27;s final flight - answer it before parking
+            // in ReadAsync, or the client waits on a response we never send.
+            if (TryReadTarget(tls.DrainPlaintext(), out ReadOnlySpan&lt;byte&gt; early))
+            {
+                await ProxyAsync(conn, client, Encoding.ASCII.GetString(early));
+            }
+
             while (true)
             {
                 RecvSnapshot snapshot = await conn.ReadAsync();
 
-                string path = &quot;/&quot;;
-                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                string? path = null;
+                unsafe
                 {
-                    if (item.HasBuffer)
+                    while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
                     {
-                        if (TryReadTarget(item.AsSpan(), out ReadOnlySpan&lt;byte&gt; target))
+                        if (item.HasBuffer)
                         {
-                            path = Encoding.ASCII.GetString(target);
+                            // Records in, plaintext out - the session decrypts what the ring got.
+                            if (TryReadTarget(tls.Decrypt(item.Ptr, item.Len), out ReadOnlySpan&lt;byte&gt; target))
+                            {
+                                path = Encoding.ASCII.GetString(target);
+                            }
+                            conn.ReturnBuffer(in item);
                         }
-                        conn.ReturnBuffer(in item);
                     }
                 }
 
-                try
+                if (path is not null)
                 {
-                    // h1 request in, h2 stream out - same ring, same thread, inline resume.
-                    using HttpClientResponse response = await client.GetAsync(path);
-
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $&quot;HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n&quot;));
-                    conn.Write(response.Body.Span);   // bytes straight through, no decode
-                }
-                catch (Exception e)
-                {
-                    byte[] message = Encoding.ASCII.GetBytes($&quot;upstream: {e.Message}&quot;);
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $&quot;HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n&quot;));
-                    conn.Write(message);
+                    await ProxyAsync(conn, client, path);
                 }
 
-                await conn.FlushAsync();
-
-                if (snapshot.IsClosed) return;
+                if (snapshot.IsClosed || tls.Closed) return;
                 conn.ResetRead();
             }
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($&quot;[proxy h1-&gt;h2] connection failed: {e.Message}&quot;);
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -1392,12 +1511,42 @@ for (int i = 0; i &lt; threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($&quot;[proxy h1-&gt;h2] {config.ReactorCount} reactors on :{config.Tcp!.Port} &quot;
-                + $&quot;-&gt; h2c {upstream.Host}:{upstream.Port}, {upstream.PoolSize} connection(s) each&quot;);
+Console.WriteLine($&quot;[proxy h1-&gt;h2] {config.ReactorCount} reactors, https on :{config.Tcp!.Port} &quot;
+                + $&quot;-&gt; h2 https://{upstreamName} ({upstreamHost}:{upstreamPort}), &quot;
+                + $&quot;{upstreamPool} connection(s) each, &quot;
+                + $&quot;verify={(upstreamInsecure ? &quot;OFF&quot; : upstreamCa ?? &quot;system store&quot;)}&quot;);
 
 foreach (Thread thread in threads)
 {
     thread.Join();
+}
+
+// One request out, one response back. Everything written here is PLAINTEXT: after the handshake
+// kTLS owns transmit, so there is nothing left for us to wrap.
+static async ValueTask ProxyAsync(TcpConnection conn, Http2ClientPool client, string path)
+{
+    try
+    {
+        // The outbound call is an h2 stream on a shared connection, not a socket of its own.
+        // Same ring, same thread - this await resumes inline.
+        using HttpClientResponse response = await client.GetAsync(path);
+
+        conn.Write(Encoding.ASCII.GetBytes(
+            $&quot;HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n&quot;));
+        conn.Write(response.Body.Span);   // bytes straight through, no decode
+    }
+    catch (Exception e)
+    {
+        // A dead origin surfaces here rather than hanging: the pool bounds the whole acquire. A
+        // REFUSED CERTIFICATE arrives the same way - the handshake is part of opening the
+        // connection, so a name mismatch reads like any other upstream failure.
+        byte[] message = Encoding.ASCII.GetBytes($&quot;upstream: {e.Message}&quot;);
+        conn.Write(Encoding.ASCII.GetBytes(
+            $&quot;HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n&quot;));
+        conn.Write(message);
+    }
+
+    await conn.FlushAsync();
 }
 
 // &quot;GET /sleep?x=1 HTTP/1.1&quot; -&gt; &quot;/sleep&quot;. Your framework of choice would do this for you; ioxide
@@ -1428,30 +1577,32 @@ static bool TryReadTarget(ReadOnlySpan&lt;byte&gt; request, out ReadOnlySpan&lt;
       <span class="pane-pkg">ioxide + ioxide.httpclient</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide ioxide.httpclient
-//   dotnet run --project Playground/Http3/Nghttp3         # h3 origin on udp :8443
-//   curl http://127.0.0.1:8080/
+//   dotnet run --project Playground/Http3/Nghttp3          # h3 origin on udp :8443
+//   PLAYGROUND_UPSTREAM_PORT=8443 dotnet run --project Playground/Proxy/H1ToH3
+//   curl -k https://127.0.0.1:8443/
 
 using System.Text;
 using ioxide;
 using ioxide.httpclient;
+using ioxide.tls;
 using ioxide.utils;
+
+const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
+const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
     ReactorCount = Environment.ProcessorCount,
     Tcp = new TcpOptions
     {
-        Port = 8080,
+        Port = 8443,
     },
 };
 
-var upstream = new Http3ClientOptions
-{
-    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
-    Port = 8443,         // the upstream&#x27;s QUIC (UDP) port
-    ServerName = &quot;localhost&quot;,
-    PoolSize = 1,         // h3 multiplexes: one connection carries all
-};
+string upstreamHost = &quot;127.0.0.1&quot;;   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = 8444;       // the upstream&#x27;s QUIC (UDP) port
+string upstreamName = &quot;localhost&quot;;    // sent as SNI, checked against the cert
+int upstreamPool = 1;                // h3 multiplexes: one connection carries all
 
 var threads = new Thread[config.ReactorCount];
 
@@ -1459,58 +1610,84 @@ for (int i = 0; i &lt; threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // Opening the pool here is what makes the reactor grow its client-side QUIC transport: an
-    // ephemeral UDP socket, armed on this ring, shared by every upstream connection.
-    reactor.OnStart = r =&gt; Http3ClientPool.Start(r, upstream);
+    reactor.OnStart = r =&gt;
+    {
+        // Inbound: terminate TLS for clients. ALPN is an ordered list and this proxy speaks one
+        // protocol, so it offers exactly one.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = [&quot;http/1.1&quot;],
+        });
+
+        // Outbound: no TLS options, because QUIC has no cleartext mode - TLS 1.3 is inside the
+        // transport and ALPN (&quot;h3&quot;) is negotiated as part of the connection handshake. Opening
+        // this pool is what makes the reactor grow its client-side QUIC transport.
+        Http3ClientPool.Start(r, new Http3ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            ServerName = upstreamName,
+            PoolSize = upstreamPool,
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =&gt;
     {
         Http3ClientPool client = r.GetService&lt;Http3ClientPool&gt;();
+        TlsSession? tls = null;
 
         try
         {
+            // The handshake reads and writes through this same connection; after it, the socket
+            // carries kTLS records the kernel en/decrypts.
+            tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
+
+            // A request can ride in with the handshake&#x27;s final flight - answer it before parking
+            // in ReadAsync, or the client waits on a response we never send.
+            if (TryReadTarget(tls.DrainPlaintext(), out ReadOnlySpan&lt;byte&gt; early))
+            {
+                await ProxyAsync(conn, client, Encoding.ASCII.GetString(early));
+            }
+
             while (true)
             {
                 RecvSnapshot snapshot = await conn.ReadAsync();
 
-                string path = &quot;/&quot;;
-                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                string? path = null;
+                unsafe
                 {
-                    if (item.HasBuffer)
+                    while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
                     {
-                        if (TryReadTarget(item.AsSpan(), out ReadOnlySpan&lt;byte&gt; target))
+                        if (item.HasBuffer)
                         {
-                            path = Encoding.ASCII.GetString(target);
+                            // Records in, plaintext out - the session decrypts what the ring got.
+                            if (TryReadTarget(tls.Decrypt(item.Ptr, item.Len), out ReadOnlySpan&lt;byte&gt; target))
+                            {
+                                path = Encoding.ASCII.GetString(target);
+                            }
+                            conn.ReturnBuffer(in item);
                         }
-                        conn.ReturnBuffer(in item);
                     }
                 }
 
-                try
+                if (path is not null)
                 {
-                    // h1 request in, h3 request out - same ring, same thread, inline resume.
-                    using HttpClientResponse response = await client.GetAsync(path);
-
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $&quot;HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n&quot;));
-                    conn.Write(response.Body.Span);   // bytes straight through, no decode
-                }
-                catch (Exception e)
-                {
-                    byte[] message = Encoding.ASCII.GetBytes($&quot;upstream: {e.Message}&quot;);
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $&quot;HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n&quot;));
-                    conn.Write(message);
+                    await ProxyAsync(conn, client, path);
                 }
 
-                await conn.FlushAsync();
-
-                if (snapshot.IsClosed) return;
+                if (snapshot.IsClosed || tls.Closed) return;
                 conn.ResetRead();
             }
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($&quot;[proxy h1-&gt;h3] connection failed: {e.Message}&quot;);
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -1519,12 +1696,41 @@ for (int i = 0; i &lt; threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($&quot;[proxy h1-&gt;h3] {config.ReactorCount} reactors on :{config.Tcp!.Port} &quot;
-                + $&quot;-&gt; h3 {upstream.Host}:{upstream.Port} (client-only QUIC, ephemeral port)&quot;);
+Console.WriteLine($&quot;[proxy h1-&gt;h3] {config.ReactorCount} reactors, https on :{config.Tcp!.Port} &quot;
+                + $&quot;-&gt; h3 {upstreamName} ({upstreamHost}:udp {upstreamPort}), &quot;
+                + $&quot;{upstreamPool} connection(s) each&quot;);
 
 foreach (Thread thread in threads)
 {
     thread.Join();
+}
+
+// One request out, one response back. Everything written here is PLAINTEXT: after the handshake
+// kTLS owns transmit, so there is nothing left for us to wrap.
+static async ValueTask ProxyAsync(TcpConnection conn, Http3ClientPool client, string path)
+{
+    try
+    {
+        // The outbound call is a QUIC stream. Both hops are completions on this same ring - one
+        // from a TCP recv, one from a UDP recv - and both resume inline.
+        using HttpClientResponse response = await client.GetAsync(path);
+
+        conn.Write(Encoding.ASCII.GetBytes(
+            $&quot;HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n&quot;));
+        conn.Write(response.Body.Span);   // bytes straight through, no decode
+    }
+    catch (Exception e)
+    {
+        // A dead origin surfaces here rather than hanging: the pool bounds the whole acquire. A
+        // refused certificate arrives the same way - for QUIC the TLS handshake IS the connection
+        // handshake, so it fails as a failed connect.
+        byte[] message = Encoding.ASCII.GetBytes($&quot;upstream: {e.Message}&quot;);
+        conn.Write(Encoding.ASCII.GetBytes(
+            $&quot;HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n&quot;));
+        conn.Write(message);
+    }
+
+    await conn.FlushAsync();
 }
 
 // &quot;GET /sleep?x=1 HTTP/1.1&quot; -&gt; &quot;/sleep&quot;. Your framework of choice would do this for you; ioxide
@@ -1555,29 +1761,38 @@ static bool TryReadTarget(ReadOnlySpan&lt;byte&gt; request, out ReadOnlySpan&lt;
       <span class="pane-pkg">ioxide + ioxide.nghttp2 + ioxide.httpclient</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide ioxide.nghttp2 ioxide.httpclient
-//   PLAYGROUND_PORT=8081 dotnet run --project Playground/Tcp/Raw   # the origin
-//   curl --http2-prior-knowledge http://127.0.0.1:8080/
+//   PLAYGROUND_PORT=8444 dotnet run --project Playground/Tls/Ktls   # a TLS origin
+//   curl -k --http2 https://127.0.0.1:8443/
 
 using System.Text;
 using ioxide;
 using ioxide.httpclient;
 using ioxide.nghttp2;
+using ioxide.tls;
+
+const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
+const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
     ReactorCount = Environment.ProcessorCount,
     Tcp = new TcpOptions
     {
-        Port = 8080,
+        Port = 8443,
     },
 };
 
-var upstream = new HttpClientOptions
-{
-    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
-    Port = 8081,
-    PoolSize = 32,        // h1 has no multiplexing: size for concurrency
-};
+string upstreamHost = &quot;127.0.0.1&quot;;   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = 8444;
+string upstreamName = &quot;localhost&quot;;    // sent as SNI, checked against the cert
+int upstreamPool = 32;               // h1 has no multiplexing: size for concurrency
+
+// The playground&#x27;s origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = certPath;
+bool upstreamInsecure = false;
 
 var threads = new Thread[config.ReactorCount];
 
@@ -1585,19 +1800,51 @@ for (int i = 0; i &lt; threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // The pool&#x27;s connections belong to THIS reactor&#x27;s ring - one pool per reactor, no locks.
-    reactor.OnStart = r =&gt; HttpClientPool.Start(r, upstream);
+    reactor.OnStart = r =&gt;
+    {
+        // Inbound: terminate TLS and offer only h2, because that is all this frontend serves. A
+        // client that cannot do h2 fails ALPN rather than silently getting something else.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = [&quot;h2&quot;],
+        });
+
+        // Outbound: one context per reactor, shared by that reactor&#x27;s pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        HttpClientPool.Start(r, new HttpClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = [&quot;http/1.1&quot;],
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =&gt;
     {
         HttpClientPool client = r.GetService&lt;HttpClientPool&gt;();
+        TlsSession? tls = null;
 
         try
         {
+            tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
+
+            // The decrypt pump lives in the pipe, so everything below is the cleartext sample -
+            // and the pipe resumes inline on this reactor, so the upstream call below does too.
+            await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+
             // Buffered + async: each stream dispatches with its body assembled, and the handler
             // may await - the upstream round trip resumes inline on this reactor. Concurrent
             // streams interleave here, which is exactly why the h1 pool has to be deep.
-            await new Nghttp2Connection(conn).RunBufferedAsync(async request =&gt;
+            await new Nghttp2Connection(pipe).RunBufferedAsync(async request =&gt;
             {
                 try
                 {
@@ -1624,7 +1871,8 @@ for (int i = 0; i &lt; threads.Length; i++)
                 catch (Exception e)
                 {
                     // Upstream down is a gateway error on this stream, not a dead h2 connection:
-                    // every other stream on it keeps working.
+                    // every other stream on it keeps working. A refused certificate arrives the
+                    // same way - the handshake is part of opening the upstream connection.
                     return new Nghttp2Response
                     {
                         Status = 502,
@@ -1633,8 +1881,13 @@ for (int i = 0; i &lt; threads.Length; i++)
                 }
             });
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($&quot;[proxy h2-&gt;h1] connection failed: {e.Message}&quot;);
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -1643,8 +1896,10 @@ for (int i = 0; i &lt; threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($&quot;[proxy h2-&gt;h1] {config.ReactorCount} reactors, h2c on :{config.Tcp!.Port} &quot;
-                + $&quot;-&gt; http/1.1 {upstream.Host}:{upstream.Port}, {upstream.PoolSize} connections each&quot;);
+Console.WriteLine($&quot;[proxy h2-&gt;h1] {config.ReactorCount} reactors, h2 over TLS on :{config.Tcp!.Port} &quot;
+                + $&quot;-&gt; https://{upstreamName} ({upstreamHost}:{upstreamPort}), &quot;
+                + $&quot;{upstreamPool} connections each, &quot;
+                + $&quot;verify={(upstreamInsecure ? &quot;OFF&quot; : upstreamCa ?? &quot;system store&quot;)}&quot;);
 
 foreach (Thread thread in threads)
 {
@@ -1658,29 +1913,38 @@ foreach (Thread thread in threads)
       <span class="pane-pkg">ioxide + ioxide.nghttp2 + ioxide.httpclient</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide ioxide.nghttp2 ioxide.httpclient
-//   PLAYGROUND_PORT=8081 dotnet run --project Playground/Http2/Nghttp2
-//   curl --http2-prior-knowledge http://127.0.0.1:8080/
+//   PLAYGROUND_PORT=8444 dotnet run --project Playground/Http2/Tls  # an h2-over-TLS origin
+//   curl -k --http2 https://127.0.0.1:8443/
 
 using System.Text;
 using ioxide;
 using ioxide.httpclient;
 using ioxide.nghttp2;
+using ioxide.tls;
+
+const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
+const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
     ReactorCount = Environment.ProcessorCount,
     Tcp = new TcpOptions
     {
-        Port = 8080,
+        Port = 8443,
     },
 };
 
-var upstream = new Http2ClientOptions
-{
-    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
-    Port = 8081,
-    PoolSize = 1,         // h2 multiplexes: one connection carries all
-};
+string upstreamHost = &quot;127.0.0.1&quot;;   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = 8444;
+string upstreamName = &quot;localhost&quot;;    // sent as SNI, checked against the cert
+int upstreamPool = 1;                // h2 multiplexes: one connection carries all
+
+// The playground&#x27;s origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = certPath;
+bool upstreamInsecure = false;
 
 var threads = new Thread[config.ReactorCount];
 
@@ -1688,15 +1952,50 @@ for (int i = 0; i &lt; threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    reactor.OnStart = r =&gt; Http2ClientPool.Start(r, upstream);
+    reactor.OnStart = r =&gt;
+    {
+        // Inbound: terminate TLS and offer only h2, because that is all this frontend serves. A
+        // client that cannot do h2 fails ALPN rather than silently getting something else.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = [&quot;h2&quot;],
+        });
+
+        // Outbound: one context per reactor, shared by that reactor&#x27;s pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        Http2ClientPool.Start(r, new Http2ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = [&quot;h2&quot;],       // h2 over TLS is chosen by ALPN, never assumed
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =&gt;
     {
         Http2ClientPool client = r.GetService&lt;Http2ClientPool&gt;();
+        TlsSession? tls = null;
 
         try
         {
-            await new Nghttp2Connection(conn).RunBufferedAsync(async request =&gt;
+            tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
+
+            // The decrypt pump lives in the pipe, so everything below is the cleartext sample -
+            // and the pipe resumes inline on this reactor, so the upstream call below does too.
+            await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+
+            // Buffered + async: each stream dispatches with its body assembled, and the handler
+            // may await - the upstream round trip resumes inline on this reactor.
+            await new Nghttp2Connection(pipe).RunBufferedAsync(async request =&gt;
             {
                 try
                 {
@@ -1706,7 +2005,9 @@ for (int i = 0; i &lt; threads.Length; i++)
                         request.Method, request.Path) { Body = request.Body });
 
                     // Copy before Dispose: the response arena is freed then, and nghttp2 copies
-                    // the h2 response only AFTER this handler returns.
+                    // the h2 response only AFTER this handler returns. A real proxy would also
+                    // drop hop-by-hop headers - Connection, Keep-Alive, Transfer-Encoding are all
+                    // illegal in h2 and would be a protocol error to forward.
                     var proxied = new Nghttp2Response
                     {
                         Status = response.Status,
@@ -1720,6 +2021,9 @@ for (int i = 0; i &lt; threads.Length; i++)
                 }
                 catch (Exception e)
                 {
+                    // Upstream down is a gateway error on this stream, not a dead h2 connection:
+                    // every other stream on it keeps working. A refused certificate arrives the
+                    // same way - the handshake is part of opening the upstream connection.
                     return new Nghttp2Response
                     {
                         Status = 502,
@@ -1728,8 +2032,13 @@ for (int i = 0; i &lt; threads.Length; i++)
                 }
             });
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($&quot;[proxy h2-&gt;h2] connection failed: {e.Message}&quot;);
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -1738,8 +2047,10 @@ for (int i = 0; i &lt; threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($&quot;[proxy h2-&gt;h2] {config.ReactorCount} reactors, h2c on :{config.Tcp!.Port} &quot;
-                + $&quot;-&gt; h2c {upstream.Host}:{upstream.Port}&quot;);
+Console.WriteLine($&quot;[proxy h2-&gt;h2] {config.ReactorCount} reactors, h2 over TLS on :{config.Tcp!.Port} &quot;
+                + $&quot;-&gt; h2 https://{upstreamName} ({upstreamHost}:{upstreamPort}), &quot;
+                + $&quot;{upstreamPool} connection(s) each, &quot;
+                + $&quot;verify={(upstreamInsecure ? &quot;OFF&quot; : upstreamCa ?? &quot;system store&quot;)}&quot;);
 
 foreach (Thread thread in threads)
 {
@@ -1753,30 +2064,32 @@ foreach (Thread thread in threads)
       <span class="pane-pkg">ioxide + ioxide.nghttp2 + ioxide.httpclient</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide ioxide.nghttp2 ioxide.httpclient
-//   dotnet run --project Playground/Http3/Nghttp3         # h3 origin on udp :8443
-//   curl --http2-prior-knowledge http://127.0.0.1:8080/
+//   dotnet run --project Playground/Http3/Nghttp3          # h3 origin on udp :8443
+//   PLAYGROUND_UPSTREAM_PORT=8443 dotnet run --project Playground/Proxy/H2ToH3
+//   curl -k --http2 https://127.0.0.1:8443/
 
 using System.Text;
 using ioxide;
 using ioxide.httpclient;
 using ioxide.nghttp2;
+using ioxide.tls;
+
+const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
+const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
     ReactorCount = Environment.ProcessorCount,
     Tcp = new TcpOptions
     {
-        Port = 8080,
+        Port = 8443,
     },
 };
 
-var upstream = new Http3ClientOptions
-{
-    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
-    Port = 8443,         // the upstream&#x27;s QUIC (UDP) port
-    ServerName = &quot;localhost&quot;,
-    PoolSize = 1,         // h3 multiplexes: one connection carries all
-};
+string upstreamHost = &quot;127.0.0.1&quot;;   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = 8444;       // the upstream&#x27;s QUIC (UDP) port
+string upstreamName = &quot;localhost&quot;;    // sent as SNI, checked against the cert
+int upstreamPool = 1;                // h3 multiplexes: one connection carries all
 
 var threads = new Thread[config.ReactorCount];
 
@@ -1784,17 +2097,45 @@ for (int i = 0; i &lt; threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // Opening the pool here is what makes the reactor grow its client-side QUIC transport: an
-    // ephemeral UDP socket, armed on this ring, shared by every upstream connection.
-    reactor.OnStart = r =&gt; Http3ClientPool.Start(r, upstream);
+    reactor.OnStart = r =&gt;
+    {
+        // Inbound: terminate TLS and offer only h2, because that is all this frontend serves. A
+        // client that cannot do h2 fails ALPN rather than silently getting something else.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = [&quot;h2&quot;],
+        });
+
+        // Outbound: no TLS options, because QUIC has no cleartext mode - TLS 1.3 is inside the
+        // transport and ALPN (&quot;h3&quot;) is negotiated as part of the connection handshake. Opening
+        // this pool is what makes the reactor grow its client-side QUIC transport.
+        Http3ClientPool.Start(r, new Http3ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            ServerName = upstreamName,
+            PoolSize = upstreamPool,
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =&gt;
     {
         Http3ClientPool client = r.GetService&lt;Http3ClientPool&gt;();
+        TlsSession? tls = null;
 
         try
         {
-            await new Nghttp2Connection(conn).RunBufferedAsync(async request =&gt;
+            tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
+
+            // The decrypt pump lives in the pipe, so everything below is the cleartext sample -
+            // and the pipe resumes inline on this reactor, so the upstream call below does too.
+            await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+
+            // Buffered + async: each stream dispatches with its body assembled, and the handler
+            // may await - the upstream round trip resumes inline on this reactor.
+            await new Nghttp2Connection(pipe).RunBufferedAsync(async request =&gt;
             {
                 try
                 {
@@ -1804,7 +2145,9 @@ for (int i = 0; i &lt; threads.Length; i++)
                         request.Method, request.Path) { Body = request.Body });
 
                     // Copy before Dispose: the response arena is freed then, and nghttp2 copies
-                    // the h2 response only AFTER this handler returns.
+                    // the h2 response only AFTER this handler returns. A real proxy would also
+                    // drop hop-by-hop headers - Connection, Keep-Alive, Transfer-Encoding are all
+                    // illegal in h2 and would be a protocol error to forward.
                     var proxied = new Nghttp2Response
                     {
                         Status = response.Status,
@@ -1818,6 +2161,9 @@ for (int i = 0; i &lt; threads.Length; i++)
                 }
                 catch (Exception e)
                 {
+                    // Upstream down is a gateway error on this stream, not a dead h2 connection:
+                    // every other stream on it keeps working. A refused certificate arrives the
+                    // same way - the handshake is part of opening the upstream connection.
                     return new Nghttp2Response
                     {
                         Status = 502,
@@ -1826,8 +2172,13 @@ for (int i = 0; i &lt; threads.Length; i++)
                 }
             });
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($&quot;[proxy h2-&gt;h3] connection failed: {e.Message}&quot;);
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -1836,8 +2187,9 @@ for (int i = 0; i &lt; threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($&quot;[proxy h2-&gt;h3] {config.ReactorCount} reactors, h2c on :{config.Tcp!.Port} &quot;
-                + $&quot;-&gt; h3 {upstream.Host}:{upstream.Port} (client-only QUIC, ephemeral port)&quot;);
+Console.WriteLine($&quot;[proxy h2-&gt;h3] {config.ReactorCount} reactors, h2 over TLS on :{config.Tcp!.Port} &quot;
+                + $&quot;-&gt; h3 {upstreamName} ({upstreamHost}:udp {upstreamPort}), &quot;
+                + $&quot;{upstreamPool} connection(s) each&quot;);
 
 foreach (Thread thread in threads)
 {
@@ -1851,7 +2203,7 @@ foreach (Thread thread in threads)
       <span class="pane-pkg">ioxide + ioxide.ngtcp2 + ioxide.nghttp3 + ioxide.httpclient</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide ioxide.ngtcp2 ioxide.nghttp3 ioxide.httpclient
-//   PLAYGROUND_PORT=8081 dotnet run --project Playground/Tcp/Raw   # the origin
+//   PLAYGROUND_PORT=8444 dotnet run --project Playground/Tls/Ktls   # a TLS origin
 //   curl --http3-only -k https://127.0.0.1:8443/
 
 using ioxide;
@@ -1877,12 +2229,18 @@ var config = new ServerConfig
     },
 };
 
-var upstream = new HttpClientOptions
-{
-    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
-    Port = 8081,
-    PoolSize = 8,         // keep-alive connections per reactor
-};
+string upstreamHost = &quot;127.0.0.1&quot;;   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = 8444;
+int upstreamPool = 8;                // keep-alive connections per reactor
+
+string upstreamName = &quot;localhost&quot;;    // sent as SNI, checked against the cert
+
+// The playground&#x27;s origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = certPath;
+bool upstreamInsecure = false;
 
 var threads = new Thread[config.ReactorCount];
 
@@ -1890,8 +2248,24 @@ for (int i = 0; i &lt; threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // The pool&#x27;s connections belong to THIS reactor&#x27;s ring - one pool per reactor, no locks.
-    reactor.OnStart = r =&gt; HttpClientPool.Start(r, upstream);
+    reactor.OnStart = r =&gt;
+    {
+        // Outbound: one context per reactor, shared by that reactor&#x27;s pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        HttpClientPool.Start(r, new HttpClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = [&quot;http/1.1&quot;],
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.QuicHandle = (r, conn) =&gt;
     {
@@ -1939,7 +2313,8 @@ for (int i = 0; i &lt; threads.Length; i++)
 }
 
 Console.WriteLine($&quot;[proxy h3-&gt;h1] {config.ReactorCount} reactors, h3 on udp :{config.Quic!.Port} &quot;
-                + $&quot;-&gt; http/1.1 {upstream.Host}:{upstream.Port}&quot;);
+                + $&quot;-&gt; https://{upstreamName} ({upstreamHost}:{upstreamPort}), &quot;
+                + $&quot;verify={(upstreamInsecure ? &quot;OFF&quot; : upstreamCa ?? &quot;system store&quot;)}&quot;);
 
 foreach (Thread thread in threads)
 {
@@ -1953,7 +2328,7 @@ foreach (Thread thread in threads)
       <span class="pane-pkg">ioxide + ioxide.ngtcp2 + ioxide.nghttp3 + ioxide.httpclient</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide ioxide.ngtcp2 ioxide.nghttp3 ioxide.httpclient
-//   PLAYGROUND_PORT=8081 dotnet run --project Playground/Http2/Nghttp2
+//   PLAYGROUND_PORT=8444 dotnet run --project Playground/Http2/Tls  # an h2-over-TLS origin
 //   curl --http3-only -k https://127.0.0.1:8443/
 
 using ioxide;
@@ -1979,12 +2354,18 @@ var config = new ServerConfig
     },
 };
 
-var upstream = new Http2ClientOptions
-{
-    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
-    Port = 8081,
-    PoolSize = 1,         // h2 multiplexes: one connection carries all
-};
+string upstreamHost = &quot;127.0.0.1&quot;;   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = 8444;
+int upstreamPool = 1;                // h2 multiplexes: one connection carries all
+
+string upstreamName = &quot;localhost&quot;;    // sent as SNI, checked against the cert
+
+// The playground&#x27;s origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = certPath;
+bool upstreamInsecure = false;
 
 var threads = new Thread[config.ReactorCount];
 
@@ -1992,7 +2373,24 @@ for (int i = 0; i &lt; threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    reactor.OnStart = r =&gt; Http2ClientPool.Start(r, upstream);
+    reactor.OnStart = r =&gt;
+    {
+        // Outbound: one context per reactor, shared by that reactor&#x27;s pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        Http2ClientPool.Start(r, new Http2ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = [&quot;h2&quot;],       // h2 over TLS is chosen by ALPN, never assumed
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.QuicHandle = (r, conn) =&gt;
     {
@@ -2036,7 +2434,8 @@ for (int i = 0; i &lt; threads.Length; i++)
 }
 
 Console.WriteLine($&quot;[proxy h3-&gt;h2] {config.ReactorCount} reactors, h3 on udp :{config.Quic!.Port} &quot;
-                + $&quot;-&gt; h2c {upstream.Host}:{upstream.Port}&quot;);
+                + $&quot;-&gt; h2 https://{upstreamName} ({upstreamHost}:{upstreamPort}), &quot;
+                + $&quot;verify={(upstreamInsecure ? &quot;OFF&quot; : upstreamCa ?? &quot;system store&quot;)}&quot;);
 
 foreach (Thread thread in threads)
 {

--- a/scripts/gen-docs-proxy-panes.py
+++ b/scripts/gen-docs-proxy-panes.py
@@ -13,40 +13,51 @@ ROOT = pathlib.Path(__file__).resolve().parent.parent
 COMBOS = {
     "H1ToH1": ("h1 &rarr; h1", "HTTP/1.1 in &middot; HTTP/1.1 out",
                "ioxide + ioxide.httpclient",
-               ["PLAYGROUND_PORT=8081 dotnet run --project Playground/Tcp/Raw   # the origin",
-                "curl http://127.0.0.1:8080/"]),
+               [
+                'PLAYGROUND_PORT=8444 dotnet run --project Playground/Tls/Ktls   # a TLS origin',
+                'curl -k https://127.0.0.1:8443/']),
     "H1ToH2": ("h1 &rarr; h2", "HTTP/1.1 in &middot; HTTP/2 out",
                "ioxide + ioxide.httpclient",
-               ["PLAYGROUND_PORT=8081 dotnet run --project Playground/Http2/Nghttp2",
-                "curl http://127.0.0.1:8080/"]),
+               [
+                'PLAYGROUND_PORT=8444 dotnet run --project Playground/Http2/Tls  # an h2-over-TLS origin',
+                'curl -k https://127.0.0.1:8443/']),
     "H1ToH3": ("h1 &rarr; h3", "HTTP/1.1 in &middot; HTTP/3 out",
                "ioxide + ioxide.httpclient",
-               ["dotnet run --project Playground/Http3/Nghttp3         # h3 origin on udp :8443",
-                "curl http://127.0.0.1:8080/"]),
+               [
+                'dotnet run --project Playground/Http3/Nghttp3          # h3 origin on udp :8443',
+                'PLAYGROUND_UPSTREAM_PORT=8443 dotnet run --project Playground/Proxy/H1ToH3',
+                'curl -k https://127.0.0.1:8443/']),
     "H2ToH1": ("h2 &rarr; h1", "HTTP/2 in &middot; HTTP/1.1 out",
                "ioxide + ioxide.nghttp2 + ioxide.httpclient",
-               ["PLAYGROUND_PORT=8081 dotnet run --project Playground/Tcp/Raw   # the origin",
-                "curl --http2-prior-knowledge http://127.0.0.1:8080/"]),
+               [
+                'PLAYGROUND_PORT=8444 dotnet run --project Playground/Tls/Ktls   # a TLS origin',
+                'curl -k --http2 https://127.0.0.1:8443/']),
     "H2ToH2": ("h2 &rarr; h2", "HTTP/2 in &middot; HTTP/2 out",
                "ioxide + ioxide.nghttp2 + ioxide.httpclient",
-               ["PLAYGROUND_PORT=8081 dotnet run --project Playground/Http2/Nghttp2",
-                "curl --http2-prior-knowledge http://127.0.0.1:8080/"]),
+               [
+                'PLAYGROUND_PORT=8444 dotnet run --project Playground/Http2/Tls  # an h2-over-TLS origin',
+                'curl -k --http2 https://127.0.0.1:8443/']),
     "H2ToH3": ("h2 &rarr; h3", "HTTP/2 in &middot; HTTP/3 out",
                "ioxide + ioxide.nghttp2 + ioxide.httpclient",
-               ["dotnet run --project Playground/Http3/Nghttp3         # h3 origin on udp :8443",
-                "curl --http2-prior-knowledge http://127.0.0.1:8080/"]),
+               [
+                'dotnet run --project Playground/Http3/Nghttp3          # h3 origin on udp :8443',
+                'PLAYGROUND_UPSTREAM_PORT=8443 dotnet run --project Playground/Proxy/H2ToH3',
+                'curl -k --http2 https://127.0.0.1:8443/']),
     "H3ToH1": ("h3 &rarr; h1", "HTTP/3 in &middot; HTTP/1.1 out",
                "ioxide + ioxide.ngtcp2 + ioxide.nghttp3 + ioxide.httpclient",
-               ["PLAYGROUND_PORT=8081 dotnet run --project Playground/Tcp/Raw   # the origin",
-                "curl --http3-only -k https://127.0.0.1:8443/"]),
+               [
+                'PLAYGROUND_PORT=8444 dotnet run --project Playground/Tls/Ktls   # a TLS origin',
+                'curl --http3-only -k https://127.0.0.1:8443/']),
     "H3ToH2": ("h3 &rarr; h2", "HTTP/3 in &middot; HTTP/2 out",
                "ioxide + ioxide.ngtcp2 + ioxide.nghttp3 + ioxide.httpclient",
-               ["PLAYGROUND_PORT=8081 dotnet run --project Playground/Http2/Nghttp2",
-                "curl --http3-only -k https://127.0.0.1:8443/"]),
+               [
+                'PLAYGROUND_PORT=8444 dotnet run --project Playground/Http2/Tls  # an h2-over-TLS origin',
+                'curl --http3-only -k https://127.0.0.1:8443/']),
     "H3ToH3": ("h3 &rarr; h3", "HTTP/3 in &middot; HTTP/3 out",
                "ioxide + ioxide.ngtcp2 + ioxide.nghttp3 + ioxide.httpclient",
-               ["PLAYGROUND_QUIC_PORT=8444 dotnet run --project Playground/Http3/Nghttp3",
-                "curl --http3-only -k https://127.0.0.1:8443/"]),
+               [
+                'PLAYGROUND_QUIC_PORT=8444 dotnet run --project Playground/Http3/Nghttp3',
+                'curl --http3-only -k https://127.0.0.1:8443/']),
 }
 
 # The trailing note on each pane: what this combination is actually for.
@@ -93,9 +104,17 @@ def inline_shared(code: str) -> str:
         'const string keyPath  = "key.pem";\n\n',
         code)
 
+    # The upstream trust anchor defaults to the same self-signed cert the frontend serves, so the
+    # samples run against each other out of the box. Collapse the override to that default.
+    code = code.replace('Env.StrOrNull("PLAYGROUND_UPSTREAM_CA") ?? certPath', "certPath")
+
     code = re.sub(r'Env\.(?:Int|Port)\("[A-Z_]+", ([^)]+)\)', r"\1", code)
     code = re.sub(r'Env\.Str\("[A-Z_]+", ("[^"]*")\)', r"\1", code)
-    assert "Env." not in code and "QuicCert" not in code, "an indirection survived"
+    code = re.sub(r'Env\.Flag\("[A-Z_]+"\)', "false", code)
+
+    assert "Env." not in code and "QuicCert" not in code, \
+        "an indirection survived: " + "; ".join(
+            l.strip() for l in code.splitlines() if "Env." in l or "QuicCert" in l)
     return code
 
 

--- a/src/clients/ioxide.file/ioxide.file.csproj
+++ b/src/clients/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.3.149</Version>
+    <Version>0.4.152</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
+++ b/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.httpclient</RootNamespace>
 
     <PackageId>ioxide.httpclient</PackageId>
-    <Version>0.3.149</Version>
+    <Version>0.4.152</Version>
     <Authors>MDA2AV</Authors>
     <Description>The ring-native HTTP client for the ioxide io_uring runtime: HTTP/1.1, HTTP/2 and HTTP/3 behind one API, with the protocol chosen per origin via Alt-Svc. One package - the h1 parser, the nghttp2 and nghttp3 bridges, client-side TLS (SNI, ALPN and certificate verification) for https:// origins, and the negotiating client - sharing one set of message types. Every response resumes the awaiting handler inline on its own reactor thread.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.pg/ioxide.pg.csproj
+++ b/src/clients/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.3.149</Version>
+    <Version>0.4.152</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.redis/ioxide.redis.csproj
+++ b/src/clients/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.3.149</Version>
+    <Version>0.4.152</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ioxide/Tls/TlsConnectionDualPipe.cs
+++ b/src/ioxide/Tls/TlsConnectionDualPipe.cs
@@ -56,7 +56,15 @@ public sealed class TlsConnectionDualPipe : IDuplexPipe, IAsyncDisposable
         _tls = session;
         _ownsSession = ownsSession;
 
-        _inbound = new Pipe(options ?? new PipeOptions(useSynchronizationContext: false));
+        // Inline schedulers, so a read resumes on the thread that completed the write - the
+        // reactor. A Pipe defaults to PipeScheduler.ThreadPool, and combined with
+        // useSynchronizationContext:false that hands the connection to a pool thread with a NULL
+        // SynchronizationContext, so nothing can post it back and the loop never returns. Every
+        // other awaitable in ioxide says the same thing as RunContinuationsAsynchronously = false.
+        _inbound = new Pipe(options ?? new PipeOptions(
+            readerScheduler: PipeScheduler.Inline,
+            writerScheduler: PipeScheduler.Inline,
+            useSynchronizationContext: false));
         _outbound = new TcpConnectionDualPipe(connection);
 
         _pump = PumpInboundAsync();

--- a/src/ioxide/ioxide.csproj
+++ b/src/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.3.149</Version>
+    <Version>0.4.152</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam. Includes TLS termination: the OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload, so handlers keep writing plaintext. TLS needs OpenSSL 3 and the Linux tls module; nothing else does, and neither is loaded unless you use it.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http2/ioxide.http2.csproj
+++ b/src/protocols/ioxide.http2/ioxide.http2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http2</RootNamespace>
 
     <PackageId>ioxide.http2</PackageId>
-    <Version>0.3.149</Version>
+    <Version>0.4.152</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure-C# HTTP/2 for the ioxide io_uring runtime: framing, HPACK (static and dynamic tables, Huffman) and flow control, with zero native code. A drop-in alternative to ioxide.nghttp2 for deployments that would rather not ship a native library - same connection shape, same request and response types.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http3/ioxide.http3.csproj
+++ b/src/protocols/ioxide.http3/ioxide.http3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http3</RootNamespace>
 
     <PackageId>ioxide.http3</PackageId>
-    <Version>0.3.149</Version>
+    <Version>0.4.152</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure C# HTTP/3 for the ioxide io_uring runtime: frame parsing, QPACK (static table + Huffman) and request dispatch with zero native dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, drop-in alternative to ioxide.nghttp3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
+++ b/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp2</RootNamespace>
 
     <PackageId>ioxide.nghttp2</PackageId>
-    <Version>0.3.149</Version>
+    <Version>0.4.152</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/2 for the ioxide io_uring runtime: framing, HPACK and flow control from nghttp2, statically linked behind a small shim with no external dependencies beyond libc. Serves HTTP/2 over any TcpConnection - h2c with prior knowledge, or h2 over TLS via ALPN - and backs the HTTP/2 client in ioxide.httpclient from the same session code. nghttp2 is sans-I/O, so ioxide keeps the ring and the loop.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
+++ b/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp3</RootNamespace>
 
     <PackageId>ioxide.nghttp3</PackageId>
-    <Version>0.3.149</Version>
+    <Version>0.4.152</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/3 layer for the ioxide io_uring runtime: nghttp3 (H3 + QPACK) bundled as a single self-contained native library with no external dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, no ioxide.ngtcp2 dependency.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
+++ b/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.ngtcp2</RootNamespace>
 
     <PackageId>ioxide.ngtcp2</PackageId>
-    <Version>0.3.149</Version>
+    <Version>0.4.152</Version>
     <Authors>MDA2AV</Authors>
     <Description>QUIC engine for the ioxide io_uring runtime: ngtcp2 + picotls bundled as a single self-contained native library (only system dependency: libcrypto.so.3 / OpenSSL 3.x). Plugs into the reactor's QUIC transport via QuicConnection. Server side; engine bindings in progress.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
+++ b/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.Kestrel</RootNamespace>
 
     <PackageId>ioxide.Kestrel</PackageId>
-    <Version>0.3.149</Version>
+    <Version>0.4.152</Version>
     <Authors>MDA2AV</Authors>
     <Description>ASP.NET Core Kestrel transport backed by the ioxide io_uring runtime: one reactor (ring) per core, SO_REUSEPORT load-balanced, with Kestrel's HTTP request loop pinned to the reactor thread. Drop-in via UseIoxide().</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/Ioxide.Tests.Harness/ReactorAffinity.cs
+++ b/tests/Ioxide.Tests.Harness/ReactorAffinity.cs
@@ -1,0 +1,59 @@
+using ioxide;
+
+namespace Ioxide.Tests;
+
+/// <summary>
+/// Records whether a handler is still running on the reactor that owns its ring, at points the
+/// test picks.
+///
+/// The invariant this exists to protect: <b>ioxide's own code must never be the reason a handler
+/// leaves its reactor.</b> The runtime does support off-reactor callers - <c>SubmitClientOp</c>
+/// hands them to <c>_remoteOps</c> and wakes the ring - but that path is an escape hatch for USER
+/// code that deliberately goes cross-thread. When one of ioxide's own seams trips it, every client
+/// call on that connection silently becomes a queue push plus an eventfd write plus a reactor
+/// wake-up, for the life of the connection, and nothing anywhere reports it.
+///
+/// The check is deliberately <see cref="Reactor.OnReactorThread"/> - the very predicate
+/// <c>SubmitClientOp</c> branches on - rather than a thread name or a SynchronizationContext, so
+/// a passing test means precisely "the marshal path would not have been taken here".
+/// </summary>
+public sealed class ReactorAffinity
+{
+    private readonly object _gate = new();
+    private readonly List<string> _drift = [];
+    private int _checks;
+
+    /// <summary>
+    /// Assert-and-record. Never throws: a handler that threw here would look like a connection
+    /// fault and the test would report the wrong thing.
+    /// </summary>
+    public void Check(Reactor reactor, string where)
+    {
+        lock (_gate)
+        {
+            _checks++;
+
+            if (reactor.OnReactorThread)
+            {
+                return;
+            }
+
+            Thread thread = Thread.CurrentThread;
+            _drift.Add($"{where}: tid={Environment.CurrentManagedThreadId} "
+                     + $"name={thread.Name ?? "<none>"} pool={thread.IsThreadPoolThread} "
+                     + $"ctx={SynchronizationContext.Current?.GetType().Name ?? "<null>"}");
+        }
+    }
+
+    /// <summary>How many observations were taken - zero means the handler never ran.</summary>
+    public int Checks
+    {
+        get { lock (_gate) { return _checks; } }
+    }
+
+    /// <summary>Every point that ran off-reactor, for the failure message.</summary>
+    public IReadOnlyList<string> Drift
+    {
+        get { lock (_gate) { return _drift.ToArray(); } }
+    }
+}

--- a/tests/Ioxide.Tests.Tls/TlsPipeTests.cs
+++ b/tests/Ioxide.Tests.Tls/TlsPipeTests.cs
@@ -30,6 +30,39 @@ internal static class TlsPipeTests
             Assert.Equal("pipe-tls-ok", body);
         }, skip: !ktls);
 
+        runner.Test("tls pipe: serving never leaves the reactor thread", () =>
+        {
+            // ioxide supports off-reactor submission - SubmitClientOp marshals through _remoteOps
+            // and wakes the ring - but that is an escape hatch for USER code that deliberately goes
+            // cross-thread. None of ioxide's own seams may trip it.
+            //
+            // TlsConnectionDualPipe did. Its inbound Pipe was built with
+            // PipeOptions(useSynchronizationContext: false) and nothing else, and a Pipe's
+            // schedulers default to PipeScheduler.ThreadPool - so the first genuinely-async
+            // ReadAsync completed on a pool thread with a NULL SynchronizationContext, which is
+            // what makes it permanent: with no context, nothing can post the connection back. From
+            // there every client call on that connection paid a queue hop and an eventfd wake, and
+            // nothing reported it. Only UdpSendTo throws on the wrong thread; the TCP path is
+            // silent, so an h3 upstream was the only way to see it at all.
+            //
+            // Checking OnReactorThread is checking the exact predicate SubmitClientOp branches on.
+            (string certPath, string keyPath) = TestCert.Ensure();
+            var options = new TlsOptions { CertificatePath = certPath, KeyPath = keyPath };
+
+            var affinity = new ReactorAffinity();
+            int port = TestServer.Start(AffinityHandler(affinity), r => TlsService.Start(r, options));
+
+            (int status, string body) = Client.GetTls(port, "/");
+            Assert.Equal(200, status);
+            Assert.Equal("pipe-tls-ok", body);
+
+            // A handler that never ran would leave Drift empty and pass vacuously.
+            Assert.True(affinity.Checks >= 2,
+                $"expected at least two observations, got {affinity.Checks}");
+            Assert.True(affinity.Drift.Count == 0,
+                "ioxide moved the handler off its reactor: " + string.Join("; ", affinity.Drift));
+        }, skip: !ktls);
+
         runner.Test("tls pipe: garbage after the handshake faults the reader, not a clean EOF", () =>
         {
             // The property both hand-rolled pumps get wrong. A TLS protocol error must reach the
@@ -55,6 +88,49 @@ internal static class TlsPipeTests
                 $"expected the decrypt to fault, got: {reason}");
         }, skip: !ktls);
     }
+
+    // Same shape as PipeHandler, with an affinity observation on either side of the await that
+    // matters: the one on the TLS pipe's reader.
+    private static Func<Reactor, TcpConnection, Task> AffinityHandler(ReactorAffinity affinity)
+        => async (reactor, connection) =>
+        {
+            TlsSession? session = null;
+            TlsConnectionDualPipe? pipe = null;
+            try
+            {
+                session = await reactor.GetService<TlsService>()!.AcceptAsync(connection);
+                affinity.Check(reactor, "after AcceptAsync");
+
+                pipe = new TlsConnectionDualPipe(connection, session);
+
+                ReadResult read = await pipe.Input.ReadAsync();
+                affinity.Check(reactor, "after Input.ReadAsync");
+                pipe.Input.AdvanceTo(read.Buffer.End);
+
+                const string body = "pipe-tls-ok";
+                pipe.Output.Write(Encoding.ASCII.GetBytes(
+                    $"HTTP/1.1 200 OK\r\nContent-Length: {body.Length}\r\n\r\n{body}"));
+                await pipe.Output.FlushAsync();
+                affinity.Check(reactor, "after Output.FlushAsync");
+            }
+            catch
+            {
+                // The client hung up, or the handshake failed - the harness probes the port with a
+                // raw TCP connection, so this fires once per run and is not a test failure.
+            }
+            finally
+            {
+                if (pipe is not null)
+                {
+                    await pipe.DisposeAsync();
+                }
+                else
+                {
+                    session?.Dispose();
+                }
+                connection.DecRef();
+            }
+        };
 
     // Serves one request off the decrypted PipeReader and answers as plaintext through the pipe's
     // writer, which is where kTLS takes over.


### PR DESCRIPTION
Started as "put TLS on both hops of the proxy examples". Finding the bug below was not the plan; the proxies are just the first handler in the repo that both terminates TLS over pipes **and** makes an outbound ring call, which is the only combination that exposes it.

## The bug

`TlsConnectionDualPipe` built its inbound Pipe as `PipeOptions(useSynchronizationContext: false)`. That flag only declines to *capture* the context — the **schedulers are separate parameters and default to `PipeScheduler.ThreadPool`**. So the first genuinely-async `Input.ReadAsync()` completed on a pool thread with a **null** `SynchronizationContext`, and the null context is what makes it permanent: nothing can post the connection back. The whole loop ran off-reactor from there.

Measured on the same binary shape, not reasoned:

```
with the fix     Http2/Tls  tid=4 name=reactor-0      pool=False ctx=ReactorSynchronizationContext
without it       Http2/Tls  tid=5 name=.NET TP Worker pool=True  ctx=<null>
control (h2c)    unaffected either way — never touches TlsConnectionDualPipe
```

**Every other sample probed clean** — `Tcp/Raw`, `Tcp/Pipe`, `Tls/Ktls`, `Tls/SslStream`, `Http2/Nghttp2`, `Http2/SslStream`, `Http3/Nghttp3`, `Clients/Pg`, `Clients/Https`. `Http2/SslStream` is worth noting: it also serves h2 over TLS through an `IDuplexPipe`, but bridges with `PipeReader.Create`, which has no scheduler knob and so keeps normal `await` semantics. Only three `new Pipe(` exist in `src/`, and Kestrel's two name their schedulers explicitly — this was the only instance.

**Why it shipped on main unnoticed.** A handler that only builds a response does not care what thread it is on, so `Http2/Tls` never failed. Exposing it needed a handler making an *outbound ring call*, and only the h3 one: `UdpSendTo` is the sole thread guard in the codebase. `SubmitClientOp` quietly marshals off-reactor callers through `_remoteOps` + an eventfd wake — correct, but precisely the cross-core handoff ioxide exists to avoid. So h2→h1 and h2→h2 "passed" while paying a queue hop per upstream call.

The fix is one line, and it says what every other awaitable in ioxide already says with `RunContinuationsAsynchronously = false`.

## TLS on both hops

All nine proxies now terminate TLS facing and speak TLS upstream:

| | facing | upstream |
|---|---|---|
| h1 / h2 frontend | kTLS (`modprobe tls`) | `TlsClientContext` |
| h3 frontend | QUIC's own TLS 1.3 | QUIC's own TLS 1.3 |

`h3 → h3` needed no TLS wiring at either end — QUIC has no cleartext mode, so both hops are TLS 1.3 by construction. That contrast is the point of keeping all nine.

The h2 frontends offer only `h2` in ALPN, which is the only way a browser reaches them. Verification is **on** by default, trusting the same self-signed cert the frontend serves so the samples run against each other; `PLAYGROUND_UPSTREAM_CA` / `_INSECURE` are the escape hatches.

## Verified

End to end against real TLS origins (`Tls/Ktls`, `Http2/Tls`, `Http3/Nghttp3`), each proxy on its own port so SO_REUSEPORT cannot merge two:

```
  combo    facing  upstream     status bytes wire   x5
  H1ToH1   h1      kTLS->https  200    8192  1.1    200 200 200 200 200
  H1ToH2   h1      kTLS->h2     200    2     1.1    200 200 200 200 200
  H1ToH3   h1      kTLS->h3     200    13    1.1    200 200 200 200 200
  H2ToH1   h2      kTLS->https  200    8192  2      200 200 200 200 200
  H2ToH2   h2      kTLS->h2     200    2     2      200 200 200 200 200
  H2ToH3   h2      kTLS->h3     200    13    2      200 200 200 200 200

  off-reactor errors across all six logs: 0
```

Two mutations prove the certificate check is not vacuous — an SNI the cert does not carry, and an unrelated trust anchor — both `502 ... certificate verify failed`. The h3 frontends' upstream halves were checked the same way: 0 handshake failures with the right anchor, 51 refusals with the wrong one. Their *facing* halves need an HTTP/3 client this box does not have.

Suites: **Unit 29, E2E 46, Http 35, Tls 4, File 2** — all green. Docs panes regenerated from the samples by `scripts/gen-docs-proxy-panes.py`.

## Open, not addressed here

- `UdpSendTo` is the only thread guard. `SubmitClientOp`'s silent marshal is how this hid for so long — making off-reactor submission visible (throw, or a debug assert) would catch the next one, but it could break callers relying on the marshal. Worth its own discussion.
- `TlsConnectionDualPipe` is the last BCL `Pipe` in core. It is there as a **buffer manager**, not an API shim — it owns the plaintext destination, the backpressure thresholds and the consumed/examined bookkeeping, none of which the zero-copy readers need because they never own memory. Replacing it means a native `TlsConnectionPipeReader` (modest win: one fewer task per connection) or kTLS RX (the real fix, and a feature).


---

## The invariant, as a test

ioxide supports off-reactor submission on purpose — `SubmitClientOp` hands the op to `_remoteOps` and wakes the ring. But that path is an **escape hatch for user code** that deliberately goes cross-thread. None of ioxide's own seams may trip it, and nothing said so or checked.

`tls pipe: serving never leaves the reactor thread` now does. It checks `Reactor.OnReactorThread` — the exact predicate `SubmitClientOp` branches on — so a pass means precisely *"the marshal path would not have been taken here"*, not a proxy for it.

**No instrumentation was added to ioxide.** A counter in `SubmitClientOp` would put a branch in the hot path and diagnostics in the runtime; the handler is test-owned, so the observation belongs there.

**Proven able to fail.** Reverting the one-line scheduler fix:

```
FAIL  tls pipe: serving never leaves the reactor thread:
      ioxide moved the handler off its reactor:
        after Input.ReadAsync:   tid=13 name=.NET TP Worker pool=True ctx=<null>
        after Output.FlushAsync: tid=15 name=.NET TP Worker pool=True ctx=<null>
```

Both drift points named, with the null `SynchronizationContext` that makes the drift permanent. Restored: **Tls 5 passed, 0 failed**.

`ReactorAffinity.Check` never throws — a handler throwing there would look like a connection fault and the test would report the wrong thing — and the test asserts on the observation count too, so a handler that never ran cannot pass vacuously.

`ReactorAffinity` lives in the harness, so other suites can adopt the same assertion for h2, h3 and the client pools.
