### PR TITLE
fix(quic): serve large HTTP/3 responses - send-retention backpressure, not connection-kill

### DIFF
--- a/Playground/Http3/Buffered/Program.cs
+++ b/Playground/Http3/Buffered/Program.cs
@@ -15,6 +15,10 @@ using Playground.Shared;
 //  The trade: memory holds the entire body, so this suits normal-sized requests. Use Playground/Http3/Nghttp3
 //  when uploads can be large or hostile.
 //
+//  It doubles as the QUIC/HTTP3 tuning reference: the Knobs block below shows every h3-path option
+//  (engine, listener, UDP, QPACK) as a literal, including maxSendRetentionBytes - the knob that
+//  bounds memory when serving large responses.
+//
 //      dotnet run -c Release --project Playground/Http3/Buffered
 //      curl --http3-only -k https://127.0.0.1:8443/
 //
@@ -26,6 +30,10 @@ using Playground.Shared;
 // Env.Override exists only so bench/run.sh can drive the sample from outside; delete those lines
 // when you copy this out and the literals above them are the entire configuration.
 
+// This sample is the QUIC/HTTP3 tuning reference: every knob the h3 path exposes is here as a
+// literal, grouped by the type it feeds. The defaults are the shipping defaults - shown, not
+// changed - so you can see the whole surface and edit one line.
+
 ushort quicPort = 8443;                        // https://127.0.0.1:8443/ over UDP - h3 lives here
 ushort tcpPort  = 8080;                        // the TCP listener, so the process serves both
 int    reactors = Environment.ProcessorCount;  // one ring per reactor, one reactor per core
@@ -33,12 +41,27 @@ int    reactors = Environment.ProcessorCount;  // one ring per reactor, one reac
 Env.Override(ref tcpPort, ref reactors);
 Env.OverrideQuic(ref quicPort, ref reactors);
 
-// UDP receive slots per reactor: how many datagrams the ring can have outstanding at once.
-int udpRecvSlots = 16;
+// ── QuicEngine: the per-endpoint QUIC/TLS state, shared by every connection ───────────────────
+uint cidLength = 8;                            // connection-id length this endpoint mints (1..20)
 
-// QPACK dynamic table. 0 keeps every header literal, which costs bytes but never blocks a
-// stream on a table update; raise it and set QpackBlockedStreams to trade one for the other.
+// Per-connection send-retention high-water. A response larger than this is streamed out paced by
+// the peer's acks instead of buffered whole, so memory stays ~this-per-connection whatever the
+// response size - the knob that lets HTTP/3 serve large files. Raise for more in-flight throughput
+// on fat links; lower to cap memory under many connections. Default 16 MiB.
+long maxSendRetentionBytes = 16L << 20;
+
+// ── QuicOptions: the listener ─────────────────────────────────────────────────────────────────
+int idleTimeoutMs = 60_000;                    // close a connection idle this long (no packets)
+
+// ── UdpOptions: how datagrams are received ────────────────────────────────────────────────────
+int  udpRecvSlots = 16;                        // multishot recv slots per reactor - datagrams the ring can hold at once
+bool gro          = true;                       // UDP_GRO: coalesce received datagrams into one recv (fewer syscalls)
+
+// ── Nghttp3Options: the HTTP/3 layer ──────────────────────────────────────────────────────────
+// QPACK dynamic table. 0 keeps every header literal, which costs bytes but never blocks a stream
+// on a table update; raise it and set QpackBlockedStreams to trade one for the other.
 long qpackCapacity = 0;
+long qpackBlockedStreams = qpackCapacity > 0 ? 100 : 0;
 
 // A real PEM pair, or null to generate a self-signed localhost cert on first run.
 string? certOverride = null;
@@ -47,17 +70,18 @@ string? keyOverride  = null;
 
 (string certPath, string keyPath) = QuicCert.Ensure(certOverride, keyOverride);
 
-using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: ["h3"]);
+using var engine = new QuicEngine(certPath, keyPath, cidLength, alpn: ["h3"], maxSendRetentionBytes);
 
 var config = new ServerConfig
 {
     ReactorCount = reactors,
     Tcp = new TcpOptions { Port = tcpPort },
-    Udp = new UdpOptions { RecvSlots = udpRecvSlots },
+    Udp = new UdpOptions { RecvSlots = udpRecvSlots, Gro = gro },
     Quic = new QuicOptions
     {
         Port = quicPort,
-        LocalCidLength = 8,
+        LocalCidLength = (int)cidLength,        // must match the engine's cidLength
+        IdleTimeoutMs = idleTimeoutMs,
         ConnectionFactory = engine.CreateFactory(),
     },
 };
@@ -65,7 +89,7 @@ var config = new ServerConfig
 var h3Options = new Nghttp3Options
 {
     QpackDynamicTableCapacity = qpackCapacity,
-    QpackBlockedStreams = qpackCapacity > 0 ? 100 : 0,
+    QpackBlockedStreams = qpackBlockedStreams,
 };
 
 // Built once and reused for every request - the h3 layer copies it into nghttp3 at submit and never

--- a/Playground/Http3/Nghttp3/Program.cs
+++ b/Playground/Http3/Nghttp3/Program.cs
@@ -27,8 +27,11 @@ using Playground.Shared;
     Env.StrOrNull("PLAYGROUND_QUIC_CERT"),
     Env.StrOrNull("PLAYGROUND_QUIC_KEY"));
 
-// One engine for the whole server. ALPN pinned to h3, so nothing else negotiates.
-using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: ["h3"]);
+// One engine for the whole server. ALPN pinned to h3, so nothing else negotiates. The last arg is
+// the per-connection send-retention high-water (default 16 MiB): a response larger than it streams
+// out paced by acks instead of buffering whole, so h3 serves large files in bounded memory. See
+// Playground/Http3/Buffered for the full QUIC/h3 knob set.
+using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: ["h3"], maxSendRetentionBytes: 16L << 20);
 
 ushort quicPort = Env.Port("PLAYGROUND_QUIC_PORT", 8443);
 

--- a/Playground/Quic/Alpn/Program.cs
+++ b/Playground/Quic/Alpn/Program.cs
@@ -35,6 +35,10 @@ Env.OverrideQuic(ref quicPort, ref reactors);
 // UDP receive slots per reactor: how many datagrams the ring can have outstanding at once.
 int udpRecvSlots = 16;
 
+// Per-connection send-retention high-water (default 16 MiB): a response larger than it streams out
+// paced by acks instead of buffering whole. See Playground/Http3/Buffered for the full knob set.
+long maxSendRetentionBytes = 16L << 20;
+
 // A real PEM pair, or null to generate a self-signed localhost cert on first run.
 string? certOverride = null;
 string? keyOverride  = null;
@@ -44,7 +48,7 @@ string? keyOverride  = null;
 
 // Permissive ALPN (no allowlist): h3 clients negotiate "h3"; everything else still handshakes
 // and falls through to the echo branch.
-using var engine = new QuicEngine(certPath, keyPath, cidLength: 8);
+using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: null, maxSendRetentionBytes);
 
 var config = new ServerConfig
 {

--- a/docs/index.html
+++ b/docs/index.html
@@ -811,34 +811,54 @@ using ioxide.utils;
 
 // ── Knobs ────────────────────────────────────────────────────────────────────────────────────
 
+// This sample is the QUIC/HTTP3 tuning reference: every knob the h3 path exposes is here as a
+// literal, grouped by the type it feeds. The defaults are the shipping defaults - shown, not
+// changed - so you can see the whole surface and edit one line.
+
 ushort quicPort = 8443;                        // https://127.0.0.1:8443/ over UDP - h3 lives here
 ushort tcpPort  = 8080;                        // the TCP listener, so the process serves both
 int    reactors = Environment.ProcessorCount;  // one ring per reactor, one reactor per core
 
 
-// UDP receive slots per reactor: how many datagrams the ring can have outstanding at once.
-int udpRecvSlots = 16;
+// ── QuicEngine: the per-endpoint QUIC/TLS state, shared by every connection ───────────────────
+uint cidLength = 8;                            // connection-id length this endpoint mints (1..20)
 
-// QPACK dynamic table. 0 keeps every header literal, which costs bytes but never blocks a
-// stream on a table update; raise it and set QpackBlockedStreams to trade one for the other.
+// Per-connection send-retention high-water. A response larger than this is streamed out paced by
+// the peer&#x27;s acks instead of buffered whole, so memory stays ~this-per-connection whatever the
+// response size - the knob that lets HTTP/3 serve large files. Raise for more in-flight throughput
+// on fat links; lower to cap memory under many connections. Default 16 MiB.
+long maxSendRetentionBytes = 16L &lt;&lt; 20;
+
+// ── QuicOptions: the listener ─────────────────────────────────────────────────────────────────
+int idleTimeoutMs = 60_000;                    // close a connection idle this long (no packets)
+
+// ── UdpOptions: how datagrams are received ────────────────────────────────────────────────────
+int  udpRecvSlots = 16;                        // multishot recv slots per reactor - datagrams the ring can hold at once
+bool gro          = true;                       // UDP_GRO: coalesce received datagrams into one recv (fewer syscalls)
+
+// ── Nghttp3Options: the HTTP/3 layer ──────────────────────────────────────────────────────────
+// QPACK dynamic table. 0 keeps every header literal, which costs bytes but never blocks a stream
+// on a table update; raise it and set QpackBlockedStreams to trade one for the other.
 long qpackCapacity = 0;
+long qpackBlockedStreams = qpackCapacity &gt; 0 ? 100 : 0;
 
 const string certPath = &quot;cert.pem&quot;;   // any PEM pair
 const string keyPath  = &quot;key.pem&quot;;
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
 
-using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: [&quot;h3&quot;]);
+using var engine = new QuicEngine(certPath, keyPath, cidLength, alpn: [&quot;h3&quot;], maxSendRetentionBytes);
 
 var config = new ServerConfig
 {
     ReactorCount = reactors,
     Tcp = new TcpOptions { Port = tcpPort },
-    Udp = new UdpOptions { RecvSlots = udpRecvSlots },
+    Udp = new UdpOptions { RecvSlots = udpRecvSlots, Gro = gro },
     Quic = new QuicOptions
     {
         Port = quicPort,
-        LocalCidLength = 8,
+        LocalCidLength = (int)cidLength,        // must match the engine&#x27;s cidLength
+        IdleTimeoutMs = idleTimeoutMs,
         ConnectionFactory = engine.CreateFactory(),
     },
 };
@@ -846,7 +866,7 @@ var config = new ServerConfig
 var h3Options = new Nghttp3Options
 {
     QpackDynamicTableCapacity = qpackCapacity,
-    QpackBlockedStreams = qpackCapacity &gt; 0 ? 100 : 0,
+    QpackBlockedStreams = qpackBlockedStreams,
 };
 
 // Built once and reused for every request - the h3 layer copies it into nghttp3 at submit and never
@@ -971,6 +991,10 @@ int    reactors = Environment.ProcessorCount;  // one ring per reactor, one reac
 // UDP receive slots per reactor: how many datagrams the ring can have outstanding at once.
 int udpRecvSlots = 16;
 
+// Per-connection send-retention high-water (default 16 MiB): a response larger than it streams out
+// paced by acks instead of buffering whole. See Playground/Http3/Buffered for the full knob set.
+long maxSendRetentionBytes = 16L &lt;&lt; 20;
+
 const string certPath = &quot;cert.pem&quot;;   // any PEM pair
 const string keyPath  = &quot;key.pem&quot;;
 // ─────────────────────────────────────────────────────────────────────────────────────────────
@@ -978,7 +1002,7 @@ const string keyPath  = &quot;key.pem&quot;;
 
 // Permissive ALPN (no allowlist): h3 clients negotiate &quot;h3&quot;; everything else still handshakes
 // and falls through to the echo branch.
-using var engine = new QuicEngine(certPath, keyPath, cidLength: 8);
+using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: null, maxSendRetentionBytes);
 
 var config = new ServerConfig
 {

--- a/docs/learn/quic-h3.html
+++ b/docs/learn/quic-h3.html
@@ -124,22 +124,40 @@
         <br><code>src/ioxide.nghttp3/*</code> + <code>libioxide_nghttp3.so</code></div></div>
     </div>
 
-    <p>Wiring it up is two lines in the host:</p>
-<pre><code class="language-csharp">var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: ["h3"]);
+    <p>Wiring it up, shown with every QUIC/h3 knob at its default
+    (<code>Playground/Http3/Buffered</code> is the same as an editable reference):</p>
+<pre><code class="language-csharp">var engine = new QuicEngine(
+    certPath, keyPath,
+    cidLength: 8,                      // connection-id length this endpoint mints
+    alpn: ["h3"],                      // pin the protocol; null accepts whatever the client offers
+    maxSendRetentionBytes: 16L &lt;&lt; 20); // send-retention high-water: bounds memory so a response
+                                       // larger than the window streams instead of buffering whole
 
 var config = new ServerConfig
 {
     Tcp = null,                        // QUIC-only: no TCP listener at all
+    Udp = new UdpOptions
+    {
+        RecvSlots = 16,                // multishot recv slots per reactor
+        Gro = true,                    // UDP_GRO: coalesce received datagrams into one recv
+    },
     Quic = new QuicOptions
     {
         Port = 8443,                   // UDP port, bound automatically on every reactor
         LocalCidLength = 8,            // must match the engine's cidLength
+        IdleTimeoutMs = 60_000,        // close a connection idle this long
         ConnectionFactory = engine.CreateFactory(),
     },
 };
 
+var h3Options = new Nghttp3Options    // the HTTP/3 layer's own knobs, passed to Nghttp3Connection
+{
+    QpackDynamicTableCapacity = 0,     // 0 = headers stay literal (never blocks on a table update)
+    QpackBlockedStreams = 0,           // raise both together to trade bytes for the dynamic table
+};
+
 reactor.TcpHandle  = Handlers.Raw;
-reactor.QuicHandle = (r, conn) => new Nghttp3Connection(conn).RunBufferedAsync(
+reactor.QuicHandle = (r, conn) => new Nghttp3Connection(conn, h3Options).RunBufferedAsync(
     static req => Nghttp3Response.Text($"hello {Encoding.ASCII.GetString(req.Path.Span)}"));</code></pre>
 
     <h2>Ingress: the life of a datagram</h2>
@@ -231,8 +249,16 @@ reactor.QuicHandle = async (r, conn) =>
       <li><b>Never drop what the engine deferred.</b> When the congestion window is full,
       <code>iq_conn_write</code> takes nothing - and the layer above (nghttp3) has already
       accounted those bytes as written and will never re-emit them. The unsent tail stays in the
-      chunk chain and is replayed on every flush (each inbound ACK, each timer) until it fits.
-      A peer that stops acking hits a 4&nbsp;MB retention cap and is closed.</li>
+      chunk chain and is replayed on every flush (each inbound ACK, each timer) until it fits.</li>
+      <li><b>Retention is a backpressure high-water, not a hard cap.</b> Retained bytes
+      (sent-but-unacked plus unsent) are bounded by <code>QuicEngine</code>'s
+      <code>maxSendRetentionBytes</code> (default 16&nbsp;MiB). A producer feeding a response checks
+      <code>CanQueueSend</code> and pauses there; as acks drain retention below the mark, the
+      ack/timer egress path fires <code>OnSendCapacityAvailable</code> to resume it - the read loop
+      never sees a download's acks, so that callback is the resume. This is what lets a response of
+      any size stream out in bounded memory rather than buffering whole. The cap only <em>closes</em>
+      the connection as a backstop, at twice the high-water, when a producer ignores backpressure and
+      keeps pushing - or when a peer simply stops acking.</li>
     </ul>
     <div class="note"><b>War story.</b> Both rules exist because their violations shipped first.
     Passing <code>fixed</code> spans of reused buffers to ngtcp2 was harmless for a while - only

--- a/src/clients/ioxide.file/ioxide.file.csproj
+++ b/src/clients/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.4.161</Version>
+    <Version>0.4.162</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
+++ b/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.httpclient</RootNamespace>
 
     <PackageId>ioxide.httpclient</PackageId>
-    <Version>0.4.161</Version>
+    <Version>0.4.162</Version>
     <Authors>MDA2AV</Authors>
     <Description>The ring-native HTTP client for the ioxide io_uring runtime: HTTP/1.1, HTTP/2 and HTTP/3 behind one API, with the protocol chosen per origin via Alt-Svc. One package - the h1 parser, the nghttp2 and nghttp3 bridges, client-side TLS (SNI, ALPN and certificate verification) for https:// origins, and the negotiating client - sharing one set of message types. Every response resumes the awaiting handler inline on its own reactor thread.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.pg/ioxide.pg.csproj
+++ b/src/clients/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.4.161</Version>
+    <Version>0.4.162</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.redis/ioxide.redis.csproj
+++ b/src/clients/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.4.161</Version>
+    <Version>0.4.162</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ioxide/Connection/Quic/QuicConnection.cs
+++ b/src/ioxide/Connection/Quic/QuicConnection.cs
@@ -62,6 +62,25 @@ public abstract class QuicConnection : IValueTaskSource<QuicRecvSnapshot>
     public abstract void SendStream(long streamId, ReadOnlySpan<byte> data, bool fin);
 
     /// <summary>
+    /// False when this connection's unacknowledged send data has reached its retention high-water:
+    /// a producer feeding a large response should pause queueing more <see cref="SendStream"/> bytes
+    /// and resume once acks drain it (the egress pump re-runs on every inbound datagram). This is
+    /// backpressure, not a hard limit - overshooting is still accepted - but a producer that ignores
+    /// it without bound eventually gets the connection closed. Base default is always true (no
+    /// backpressure); a real engine connection reports its retention state.
+    /// </summary>
+    public virtual bool CanQueueSend => true;
+
+    /// <summary>
+    /// Invoked on the reactor thread when send retention drains back below the high-water after
+    /// <see cref="CanQueueSend"/> had gone false - the signal for a paused producer (e.g. an h3
+    /// response pump) to resume queueing. Fires from the ack/timer egress path, which the read loop
+    /// does not see (a downloading peer sends only acks), so it is the only resume trigger for a
+    /// response larger than the retention window.
+    /// </summary>
+    public Action? OnSendCapacityAvailable { get; set; }
+
+    /// <summary>
     /// Open a server-initiated unidirectional stream (H3 control / QPACK); returns its id, or a
     /// negative value if the engine can't (peer allowance exhausted, or no engine). Reactor thread
     /// only.

--- a/src/ioxide/ioxide.csproj
+++ b/src/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.4.161</Version>
+    <Version>0.4.162</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam. Includes TLS termination: the OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload, so handlers keep writing plaintext. TLS needs OpenSSL 3 and the Linux tls module; nothing else does, and neither is loaded unless you use it.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http2/ioxide.http2.csproj
+++ b/src/protocols/ioxide.http2/ioxide.http2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http2</RootNamespace>
 
     <PackageId>ioxide.http2</PackageId>
-    <Version>0.4.161</Version>
+    <Version>0.4.162</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure-C# HTTP/2 for the ioxide io_uring runtime: framing, HPACK (static and dynamic tables, Huffman) and flow control, with zero native code. A drop-in alternative to ioxide.nghttp2 for deployments that would rather not ship a native library - same connection shape, same request and response types.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http3/ioxide.http3.csproj
+++ b/src/protocols/ioxide.http3/ioxide.http3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http3</RootNamespace>
 
     <PackageId>ioxide.http3</PackageId>
-    <Version>0.4.161</Version>
+    <Version>0.4.162</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure C# HTTP/3 for the ioxide io_uring runtime: frame parsing, QPACK (static table + Huffman) and request dispatch with zero native dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, drop-in alternative to ioxide.nghttp3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
+++ b/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp2</RootNamespace>
 
     <PackageId>ioxide.nghttp2</PackageId>
-    <Version>0.4.161</Version>
+    <Version>0.4.162</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/2 for the ioxide io_uring runtime: framing, HPACK and flow control from nghttp2, statically linked behind a small shim with no external dependencies beyond libc. Serves HTTP/2 over any TcpConnection - h2c with prior knowledge, or h2 over TLS via ALPN - and backs the HTTP/2 client in ioxide.httpclient from the same session code. nghttp2 is sans-I/O, so ioxide keeps the ring and the loop.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp3/Connection/Nghttp3Connection.Egress.cs
+++ b/src/protocols/ioxide.nghttp3/Connection/Nghttp3Connection.Egress.cs
@@ -41,6 +41,14 @@ public sealed partial class Nghttp3Connection
         {
             while (true)
             {
+                // Backpressure: stop draining a large response once the connection's send retention
+                // is at its high-water. nghttp3 holds the un-pulled tail; the RunBuffered loop calls
+                // PumpEgress again on the next inbound datagram (acks drain retention), so it resumes.
+                if (!_quicConnection.CanQueueSend)
+                {
+                    return;
+                }
+
                 long streamId;
                 int fin;
                 long producedBytes = Nghttp3.ih3_writev(_nghttp3Handle, &streamId, &fin, egressPointer, (nuint)_egress.Length);

--- a/src/protocols/ioxide.nghttp3/Connection/Nghttp3Connection.cs
+++ b/src/protocols/ioxide.nghttp3/Connection/Nghttp3Connection.cs
@@ -59,6 +59,11 @@ public sealed partial class Nghttp3Connection : IDisposable
     {
         _quicConnection = quicConnection;
         _options = options ?? Nghttp3Options.Default;
+
+        // A response larger than the QUIC send-retention window is drained in PumpEgress under
+        // backpressure (it stops at the high-water); this resumes it as acks free retention, since
+        // the run loop only wakes on inbound request data - not on the acks of a download.
+        _quicConnection.OnSendCapacityAvailable = PumpEgress;
     }
 
     /// <summary>Buffered, synchronous: dispatch at end-of-stream with the whole body pre-assembled

--- a/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
+++ b/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp3</RootNamespace>
 
     <PackageId>ioxide.nghttp3</PackageId>
-    <Version>0.4.161</Version>
+    <Version>0.4.162</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/3 layer for the ioxide io_uring runtime: nghttp3 (H3 + QPACK) bundled as a single self-contained native library with no external dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, no ioxide.ngtcp2 dependency.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.ngtcp2/Connection/QuicEngineConnection.Egress.cs
+++ b/src/protocols/ioxide.ngtcp2/Connection/QuicEngineConnection.Egress.cs
@@ -88,6 +88,15 @@ public unsafe partial class QuicEngineConnection
     {
         ReplayOut();
         FlushConnection();
+
+        // Acks (processed just before this on the inbound path) freed retention: if a producer
+        // paused at the high-water, tell it to resume queueing. The read loop never sees these acks,
+        // so this is the resume trigger for a response larger than the retention window.
+        if (_sendAtCapacity && !_closed && _outRetained < _maxSendRetention)
+        {
+            _sendAtCapacity = false;
+            OnSendCapacityAvailable?.Invoke();
+        }
     }
 
     // Drain ngtcp2's own frames (ACKs, handshake, CRYPTO, MAX_STREAMS) until it has nothing more.

--- a/src/protocols/ioxide.ngtcp2/Connection/QuicEngineConnection.SendStream.cs
+++ b/src/protocols/ioxide.ngtcp2/Connection/QuicEngineConnection.SendStream.cs
@@ -29,9 +29,22 @@ public unsafe partial class QuicEngineConnection
     private readonly List<long> _outPending = [];
     private long _outRetained;
 
-    // A peer that stops ACKing gets closed rather than buffered without bound (retained =
-    // sent-but-unacked + unsent, across all streams).
-    private const long OutRetainedCap = 4 << 20;
+    // Send-retention high-water (retained = sent-but-unacked + unsent, across all streams). A
+    // cooperative producer checks CanQueueSend and pauses here, so a response of any size streams
+    // through in ~this much memory. Seeded from the engine; the client ctor keeps the default.
+    private long _maxSendRetention = 16 << 20;
+
+    // Hard backstop: a producer that ignores CanQueueSend and keeps pushing gets closed rather than
+    // buffered without bound. Set well above the high-water so cooperative producers never hit it.
+    private long OutRetainedCeiling => _maxSendRetention * 2;
+
+    /// <summary>False once retained send data reaches the high-water: pause queueing more and let
+    /// acks drain it (the egress pump re-runs on every inbound datagram).</summary>
+    public override bool CanQueueSend => !_closed && _outRetained < _maxSendRetention;
+
+    // Set when a producer filled retention to the high-water; FlushEgress fires the resume callback
+    // and clears it once acks bring retention back down.
+    private bool _sendAtCapacity;
 
     /// <summary>Queue bytes on a stream and flush. streamId must come from a delivered item or
     /// <see cref="OpenUniStream"/>. fin closes the send side. Never discards: bytes are retained
@@ -64,9 +77,14 @@ public unsafe partial class QuicEngineConnection
         }
         os.Fin |= fin;
 
-        if (_outRetained > OutRetainedCap)
+        if (_outRetained >= _maxSendRetention)
         {
-            Console.Error.WriteLine("[ioxide.ngtcp2] send retention cap exceeded; closing connection.");
+            _sendAtCapacity = true;   // arms the resume: FlushEgress fires it once acks drain below
+        }
+
+        if (_outRetained > OutRetainedCeiling)
+        {
+            Console.Error.WriteLine("[ioxide.ngtcp2] send retention backstop exceeded (producer ignored backpressure); closing connection.");
             _closed = true;
             _reactor.QuicRemoveConnection(this);
             Destroy();

--- a/src/protocols/ioxide.ngtcp2/Connection/QuicEngineConnection.cs
+++ b/src/protocols/ioxide.ngtcp2/Connection/QuicEngineConnection.cs
@@ -56,12 +56,14 @@ public unsafe partial class QuicEngineConnection : QuicConnection
     public QuicEngineConnection(QuicEngine engine)
     {
         _engine = engine;
+        _maxSendRetention = engine.MaxSendRetentionBytes;
     }
 
     /// <summary>Client-side connection; <see cref="QuicClientEngine.Connect"/> builds these.</summary>
     public QuicEngineConnection(QuicClientEngine clientEngine)
     {
         _clientEngine = clientEngine;
+        // Client request bodies are small; the default high-water is plenty and needs no knob.
     }
 
     /// <summary>Handshake finished; safe to open server-initiated streams and send.</summary>

--- a/src/protocols/ioxide.ngtcp2/Engine/QuicEngine.cs
+++ b/src/protocols/ioxide.ngtcp2/Engine/QuicEngine.cs
@@ -26,13 +26,25 @@ public sealed unsafe class QuicEngine : IDisposable
     public uint CidLength { get; }
 
     /// <summary>
+    /// Per-connection send-retention high-water: how many unacknowledged response bytes a
+    /// connection buffers before it applies backpressure (the egress pump stops pulling more of a
+    /// response until acks drain it). Bounds memory to roughly this per connection regardless of
+    /// response size, so a large file streams through without buffering all of it. Default 16 MiB.
+    /// </summary>
+    public long MaxSendRetentionBytes { get; }
+
+    /// <summary>
     /// alpn: the protocols this server accepts, preference-ordered (e.g. ["h3"]). A client offering
     /// none of them fails the handshake with no_application_protocol (RFC 9001 §8.1). Null/empty:
     /// accept whichever protocol the client offers first (the pre-H3 permissive behavior).
     /// </summary>
-    public QuicEngine(string certPemPath, string keyPemPath, uint cidLength = 8, string[]? alpn = null)
+    public QuicEngine(string certPemPath, string keyPemPath, uint cidLength = 8, string[]? alpn = null,
+        long maxSendRetentionBytes = 16L << 20)
     {
         CidLength = cidLength;
+        // Clamp to a floor: the pump overshoots the high-water by at most one egress chunk (16 KiB),
+        // so a cap below that would wedge a response mid-flight. 256 KiB gives comfortable headroom.
+        MaxSendRetentionBytes = Math.Max(maxSendRetentionBytes, 256L << 10);
 
         var callbacks = new Ngtcp2.Callbacks
         {

--- a/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
+++ b/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.ngtcp2</RootNamespace>
 
     <PackageId>ioxide.ngtcp2</PackageId>
-    <Version>0.4.161</Version>
+    <Version>0.4.162</Version>
     <Authors>MDA2AV</Authors>
     <Description>QUIC engine for the ioxide io_uring runtime: ngtcp2 + picotls bundled as a single self-contained native library (only system dependency: libcrypto.so.3 / OpenSSL 3.x). Plugs into the reactor's QUIC transport via QuicConnection. Server side; engine bindings in progress.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
+++ b/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.Kestrel</RootNamespace>
 
     <PackageId>ioxide.Kestrel</PackageId>
-    <Version>0.4.161</Version>
+    <Version>0.4.162</Version>
     <Authors>MDA2AV</Authors>
     <Description>ASP.NET Core Kestrel transport backed by the ioxide io_uring runtime: one reactor (ring) per core, SO_REUSEPORT load-balanced, with Kestrel's HTTP request loop pinned to the reactor thread. Drop-in via UseIoxide().</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## The bug

HTTP/3 responses larger than **~3 MB stalled** - the client saw the connection die mid-transfer. Small assets were unaffected, which is why it hid.

Root cause: the QUIC send path kept a **4 MB retention cap** and *closed the connection* when it was exceeded (`QuicEngineConnection.SendStream.cs`). `PumpEgress` drained the entire response body out of nghttp3 into per-connection retention in one tight loop with no backpressure, so a response over 4 MB piled into retention faster than acks freed it and tripped the cap.

Confirmed with a clean threshold on a fresh server (curl-http3, byte-integrity checked): ≤3 MB worked, ≥4 MB stalled - matching the 4 MB cap exactly.

## The fix - backpressure, not a kill switch

- `QuicConnection` gains **`CanQueueSend`** (retention below the high-water?) and an **`OnSendCapacityAvailable`** resume callback. `PumpEgress` checks the first and pauses at the high-water, leaving the tail in nghttp3.
- **The resume is the missing link:** the run loop only wakes on inbound *request* data, but a downloading peer sends only acks. `FlushEgress` - which runs on every ack/timer - fires `OnSendCapacityAvailable` once acks drain retention below the mark, and `Nghttp3Connection` wires that to `PumpEgress`. So the response streams out paced by acks.
- The high-water is **configurable** via `QuicEngine(maxSendRetentionBytes:)` (default **16 MiB**, up from the old 4 MB const); the hard close stays as a backstop at **2×** for a producer that ignores backpressure.

Result: **bounded memory (~high-water per connection) for a response of any size.**

## Verified

curl-http3, sha256 byte-integrity, fresh server:

| size | result | speed |
|---|---|---|
| 4 MB | 200, SHA-OK | 127 MB/s |
| 10 MB | 200, SHA-OK | 354 MB/s |
| 50 MB | 200, SHA-OK | 411 MB/s |
| 100 MB | 200, SHA-OK | 452 MB/s |

100 MB served in 0.23 s in 16 MiB of buffer; small-body path unchanged; no server errors. Was: anything over ~3 MB stalled.

## Also in this PR

- **Examples + docs:** `Playground/Http3/Buffered` is now the QUIC/h3 tuning reference (every knob as a literal, including `maxSendRetentionBytes`); `Http3/Nghttp3` and `Quic/Alpn` gain the new knob; `docs/learn/quic-h3.html` shows the full wiring and corrects the retention-contract section (backpressure high-water, not a 4 MB hard cap); panes regenerated.
- **0.4.162** across all eleven packages.

Touches the hand-written `ioxide` core (`QuicConnection.cs`), so flagging for review.